### PR TITLE
initial release of image component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the lerna-managed monorepo for the components that make up the Engine Theme SDK.
 
-This monorepo is a collection of packages for blocks and SDK components, but they are all versioned separately for now so that they can be patched separately.
+This monorepo is a collection of packages for SDK components, but they are all versioned separately for now so that they can be patched separately.
 
 ## Instructions
 
@@ -13,56 +13,54 @@ Lerna requires some setup and know-how, so be sure to read the instructions belo
 Lerna can be run with `npx` from the root repo directory once we've cloned it:
 
 ```sh
-$ git clone git@github.com:WPMedia/fusion-news-theme-blocks.git
-$ cd fusion-news-theme-blocks
+$ git clone git@github.com:WPMedia/engine-theme-sdk.git
+$ cd engine-theme-sdk
 $ npx lerna list
 # lerna prints a list of all packages in our monorepo
 ```
 
 ### Creating a new package
 
-#### New block
+#### New SDK Component
 
-If we wanted to create a new block for our theme called `new-footer-block` the command we'd run with lerna would look something like this.
+If we wanted to create a new component for our theme called `image` the command we'd run with lerna would look something like this.
 
 ```sh
-npx lerna create @arc-test-org/new-footer-block blocks/new-footer-block
+npx lerna create @arc-test-org/image components/image
 ```
 
-The CLI will go through a bunch of questions, can accept all of them for now because we're going to replace most of what it'll generate. In fact the above command can be run with a `--yes` arg to just accept the default for each prompt automatically.
+The CLI will go through a bunch of questions, can accept all of them for now because we're going to alter some of what it'll generate. In fact the above command can be run with a `--yes` arg to just accept the default for each prompt automatically.
 
-From there we need to update our `package.json` for our new block since the lerna-generated `package.json` is almost entirely useless for blocks. For example, the generated `package.json` includes several references to a `lib` directory. We do not typically have such a directory for blocks.
-
-The structure of blocks is largely incompatible with what lerna generates in this init process, we'll want our `package.json` to look something like this:
+From there we need to update our `package.json` for our new component. We'll want our `package.json` to look something like this:
 
 ```json
 {
-  "name": "@arc-test-org/header-nav-block",
+  "name": "@arc-test-org/image",
   "version": "0.0.0",
-  "description": "Fusion News Theme header nav block",
-  "author": "Joe Grosspietsch <joe.grosspietsch@washpost.com>",
-  "homepage": "https://github.com/WPMedia/fusion-news-theme-blocks",
+  "description": "Thumbor and lazy loading Image component",
+  "author": "Brent Miller <brent.miller@washport.com>",
+  "homepage": "https://github.com/WPMedia/engine-theme-sdk#readme",
   "license": "UNLICENSED",
-  "main": "index.js",
+  "main": "lib/image.js",
+  "directories": {
+    "lib": "lib"
+  },
   "files": [
-    "features",
-    "chains",
-    "layouts"
+    "lib"
   ],
   "publishConfig": {
     "access": "restricted"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "lint": "eslint --ext js --ext jsx features"
+    "lint": "eslint --ext js --ext jsx lib"
   }
 }
 ```
 
-Note three things here:
+Couple things to note here:
 
 1. The initial version is set to `0.0.0`. This is because on your initial commit you are going to choose the first version you want to publish. Otherwise, it will default to `1.0.0` and then you'll need to bump up the package version no matter what once you publish.
-2. The `files` consists of three directories: `features`, `chains`, and `layouts`. These are the three types of components blocks currently support. You'll want to delete the `lib` and `__tests__` directories from your repo as well as the `files` list.
 3. There is a `lint` script in the `scripts`. This script is run with `npx lerna run lint` at the root although it can also be run with `npm run lint` if the package root is your working directory.
 
 ### Installing `node_modules`

--- a/components/image/lib/image.jsx
+++ b/components/image/lib/image.jsx
@@ -3,7 +3,35 @@ import React, { Component } from 'react';
 import Static from 'fusion:static';
 import buildThumborURL from './thumbor-image-url';
 
-
+/**
+ * Image component that has basic Thumbor and lazy loading support.
+ *
+ * The Thumbor support assumes that the feature pack leveraging this component will have the
+ * packaage "thumbor-lite" installed via NPM. The requirement for thumbor-lite is through a dynamic require to enforce
+ * its usaage server-side...See the file in this repository: components/image/lib/thumbor-image-url.js
+ *
+ * Also, the lazy loading assumes that that the feature pack will have the Yall library (https://github.com/malchata/yall.js)
+ * installed in resources/js/yall.min.js along with an additional script to bootstrap the library.  For example, a script called
+ * resources/js/image-lazy.js and basically has this one line of code:  document.addEventListener('DOMContentLoaded', yall).
+ * These two scripts are then included in an output-type file like this:
+ *
+ * <script type="text/javascript" src={deployment(`${contextPath}/resources/js/yall.min.js`)} />
+ * <script type="text/javascript" src={deployment(`${contextPath}/resources/js/image-lazy.js`)} />
+ *
+ * Note: This component needs to be extended to allow for Thumbor ratio and focal point values that are set by the
+ * producer.
+ *
+ * @constructor
+ * @param {string} URL - URL to the unoptimized image.
+ * @param {string} alt - The author of the book.
+ * @param {number} smallWidth - Width of the image to crop to for the small break point
+ * @param {number} smallHeight - Height of the image to crop to for the small break point
+ * @param {number} mediumWidth - Width of the image to crop to for the medium break point
+ * @param {number} mediumHeight - Height of the image to crop to for the medium break point
+ * @param {number} largeWidth - Width of the image to crop to for the large break point
+ * @param {number} largeHeight - Height of the image to crop to for the large break point
+ * @param {string} defaultImage - URI to default (or fall back image), ex 'resources/images/default_feed_image.jpg'.
+ */
 class Image extends Component {
     static DEFAULT_IMAGE = 'resources/images/default_feed_image.jpg';
 


### PR DESCRIPTION
I felt since this repo was just going to be comprised of SDK components, more of the defaults that Lerna uses (like lib) were fine to use...please advise if a better way should be incorporated.  One thing that bothers my is that to use the image component in either the blocks or feature pack, you have to import it like this:

import Image from '@arc-test-org/image/lib/image';

I would like to be able to do just:

import Image from '@arc-test-org/image';

I would love any insight on how to configure Lerna properly to get that done.

Also, please read the JSDoc in components/image/lib/image.jsx to understand how the external dependencies (thumbor-lite and Yall.js) are not included in this repo but will be required all the way at the feature pack level.

Finally, if you wish to try this out, it requires Joe's fusion branch:  https://github.com/WPMedia/fusion/tree/block-support-poc