### PR TITLE
New reusable metadata component

### DIFF
--- a/docs/components/MetaData/README.md
+++ b/docs/components/MetaData/README.md
@@ -1,0 +1,42 @@
+#MetaData
+
+##Description:
+The MetaData component is to be used only with-in output-type components. 
+It handles the rendering of the title tags and all meta tags with the 
+exception of the viewport meta tag.
+
+##Usage
+
+To import into an output-type component:
+`import { MetaData } from '@wpmedia/engine-theme-sdk';`
+
+###Props:
+
+- MetaTag (required): The MetaTag function that is passed into an output type.
+- MetaTags (required): The MetaTags function that is passed into an output type.
+- metaValue (required): The metaValue function that is passed into an output type.
+- globalContent (optional): The globalContent object that is obtained from the `useFusionContext()`
+in the `fusion:context` module.
+- websiteName (optional): The name of the website.
+- twitterSite (optional): The corresponding twitter site name.
+
+##Note
+This component should be placed high in the `<head>` section of the 
+output-type see example below for ideal positioning:
+
+```
+      <head>  
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {gtmID
+          ? (
+            <script dangerouslySetInnerHTML={{ __html: gaScript }} />
+          ) : null}
+        <MetaData
+          MetaTag={MetaTag}
+          MetaTags={MetaTags}
+          metaValue={metaValue}
+          globalContent={gc}
+          websiteName={websiteName}
+          twitterSite={twitterSite}
+        />
+``` 

--- a/jest/mocks/environment.js
+++ b/jest/mocks/environment.js
@@ -1,7 +1,12 @@
 /* eslint-disable import/prefer-default-export */
 const TIMEZONE = 'America/Chicago';
 
+const resizerKey = '%{FKDFJK}';
+const resizerURL = 'https://fake.cdn.com/resizer';
+
 // Don't export as default so the conventional destructuring assignment can be used
 export {
   TIMEZONE,
+  resizerKey,
+  resizerURL,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -1,0 +1,912 @@
+/**
+ * this is for mocking node env
+ * will not have window attribute, testing ssr
+ * https://jestjs.io/docs/en/configuration.html#testenvironment-string
+ * @jest-environment node
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import getProperties from 'fusion:properties';
+import MetaData from './index';
+
+jest.mock('react-dom/server', () => ({
+  renderToString: jest.fn().mockReturnValue('<meta />'),
+}));
+
+getProperties.mockImplementation(() => ({
+  websiteName: 'The Sun',
+  twitterSite: 'https://www.twitter.com/the-sun',
+  dangerouslyInjectJS: [],
+}));
+
+describe('the meta data ', () => {
+  describe('if page type is article', () => {
+    const metaValue = (prop): string | null => {
+      if (prop === 'page-type') {
+        return 'article';
+      }
+      if (prop === 'title') {
+        return 'the-sun';
+      }
+      return null;
+    };
+
+    const useFusionContext = {
+      globalContent: {
+        description: {
+          basic: 'this is a description',
+        },
+        headlines: {
+          basic: 'this is a headline',
+        },
+        taxonomy: {
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          seo_keywords: [
+            'keyword1',
+            'keyword2',
+          ],
+          tags: [
+            { slug: 'tag1' },
+            { slug: 'tag2' },
+          ],
+        },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        promo_items: {
+          basic: {
+            url: 'awesome-url',
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            alt_text: 'alt text',
+          },
+        },
+      },
+      arcSite: 'the-sun',
+    };
+    const { globalContent, arcSite } = useFusionContext;
+    const {
+      websiteName, twitterSite,
+    } = getProperties(arcSite);
+
+    const wrapper = shallow(<MetaData
+      metaValue={metaValue}
+      MetaTag={jest.fn()}
+      MetaTags={jest.fn()}
+      globalContent={globalContent}
+      twitterSite={twitterSite}
+      websiteName={websiteName}
+    />);
+    it('should have a title', () => {
+      expect(wrapper.find('title').length).toBe(1);
+    });
+
+    it('should have meta tags', () => {
+      expect(wrapper.find('meta').length).toBe(9);
+    });
+  });
+  describe('when a video page type is provided', () => {
+    describe('when global content is provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'video';
+        }
+        return null;
+      };
+
+      const useFusionContext = {
+        globalContent: {
+          description: {
+            basic: 'this is a video description',
+          },
+          headlines: {
+            basic: 'this is a video headline',
+          },
+          taxonomy: {
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            seo_keywords: [
+              'keyword1',
+              'keyword2',
+            ],
+            tags: [
+              { slug: 'tag1' },
+              { slug: 'tag2' },
+            ],
+          },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          promo_items: {
+            basic: {
+              url: 'awesome-url',
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              alt_text: 'alt text',
+            },
+          },
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+
+      it('should have a title tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a video headline – The Sun');
+      });
+
+      it('should have a video description meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a video description');
+      });
+
+      it('should have a video keywords meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='keywords']").props().content).toBe('keyword1,keyword2');
+      });
+
+      it('should have a video og:title meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a video headline');
+      });
+
+      it('should have a video og:image meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:image']").props().content).toBe('https://fake.cdn.com/resizer/l_1yxKdAU0rtnyaww9LofnGAFkw=/1200x630/awesome-url');
+      });
+
+      it('should have a video og:image:alt meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:image:alt']").props().content).toBe('alt text');
+      });
+
+      it('should not have a robots meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+    });
+    describe('when global content is not provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'video';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: null,
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+      });
+
+      it('should not have a video description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").length).toBe(0);
+      });
+
+      it('should not have a video keywords meta tag', () => {
+        expect(wrapper.find("meta[name='keywords']").length).toBe(0);
+      });
+
+      it('should have a video og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
+      });
+
+      it('should have a video og:image meta tag', () => {
+        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+      });
+
+      it('should not have a video og:image:alt meta tag', () => {
+        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
+      });
+
+      it('should not have a robots meta tag', () => {
+        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+    });
+    describe('when custom tags are provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'video';
+        }
+        if (prop === 'description') {
+          return 'this is a custom description';
+        }
+        if (prop === 'title') {
+          return 'this is a custom title';
+        }
+        if (prop === 'og:title') {
+          return 'this is a custom og:title';
+        }
+        if (prop === 'keywords') {
+          return 'custom-keyword1,custom-keyword2';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: {
+          description: {
+            basic: 'this is a video description',
+          },
+          headlines: {
+            basic: 'this is a video headline',
+          },
+          taxonomy: {
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            seo_keywords: [
+              'keyword1',
+              'keyword2',
+            ],
+            tags: [
+              { slug: 'tag1' },
+              { slug: 'tag2' },
+            ],
+          },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          promo_items: {
+            basic: {
+            },
+          },
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom title – The Sun');
+      });
+
+      it('should not have a video description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
+      });
+
+      it('should not have a video keywords meta tag', () => {
+        expect(wrapper.find("meta[name='keywords']").props().content).toBe('custom-keyword1,custom-keyword2');
+      });
+
+      it('should have a video og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title');
+      });
+
+      it('should have a video og:image meta tag', () => {
+        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+      });
+
+      it('should not have a video og:image:alt meta tag', () => {
+        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
+      });
+
+      it('should not have a robots meta tag', () => {
+        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+    });
+  });
+  describe('when a gallery page type is provided', () => {
+    describe('when global content is provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'gallery';
+        }
+        return null;
+      };
+
+      const useFusionContext = {
+        globalContent: {
+          description: {
+            basic: 'this is a gallery description',
+          },
+          headlines: {
+            basic: 'this is a gallery headline',
+          },
+          taxonomy: {
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            seo_keywords: [
+              'keyword1',
+              'keyword2',
+            ],
+            tags: [
+              { slug: 'tag1' },
+              { slug: 'tag2' },
+            ],
+          },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          promo_items: {
+            basic: {
+              url: 'awesome-url',
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              alt_text: 'alt text',
+            },
+          },
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+
+      it('should have a title tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a gallery headline – The Sun');
+      });
+
+      it('should have a gallery description meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a gallery description');
+      });
+
+      it('should have a gallery keywords meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='keywords']").props().content).toBe('keyword1,keyword2');
+      });
+
+      it('should have a gallery og:title meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a gallery headline');
+      });
+
+      it('should have a gallery og:image meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:image']").props().content).toBe('https://fake.cdn.com/resizer/l_1yxKdAU0rtnyaww9LofnGAFkw=/1200x630/awesome-url');
+      });
+
+      it('should have a gallery og:image:alt meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:image:alt']").props().content).toBe('alt text');
+      });
+
+      it('should not have a robots meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+    });
+
+    describe('when global content is not provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'gallery';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: null,
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+      });
+
+      it('should have a gallery description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").length).toBe(0);
+      });
+
+      it('should have a gallery keywords meta tag', () => {
+        expect(wrapper.find("meta[name='keywords']").length).toBe(0);
+      });
+
+      it('should have a gallery og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
+      });
+
+      it('should have a gallery og:image meta tag', () => {
+        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+      });
+
+      it('should have a gallery og:image:alt meta tag', () => {
+        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
+      });
+
+      it('should not have a robots meta tag', () => {
+        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+    });
+
+    describe('when custom tags are provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'gallery';
+        }
+        if (prop === 'description') {
+          return 'this is a custom description';
+        }
+        if (prop === 'title') {
+          return 'this is a custom title';
+        }
+        if (prop === 'og:title') {
+          return 'this is a custom og:title';
+        }
+        if (prop === 'keywords') {
+          return 'custom-keyword1,custom-keyword2';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: {
+          description: {
+            basic: 'this is a gallery description',
+          },
+          headlines: {
+            basic: 'this is a gallery headline',
+          },
+          taxonomy: {
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            seo_keywords: [
+              'keyword1',
+              'keyword2',
+            ],
+            tags: [
+              { slug: 'tag1' },
+              { slug: 'tag2' },
+            ],
+          },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          promo_items: {
+          },
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom title – The Sun');
+      });
+
+      it('should have a gallery description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
+      });
+
+      it('should have a gallery keywords meta tag', () => {
+        expect(wrapper.find("meta[name='keywords']").props().content).toBe('custom-keyword1,custom-keyword2');
+      });
+
+      it('should have a gallery og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title');
+      });
+
+      it('should have a gallery og:image meta tag', () => {
+        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+      });
+
+      it('should have a gallery og:image:alt meta tag', () => {
+        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
+      });
+
+      it('should not have a robots meta tag', () => {
+        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+    });
+  });
+  describe('when an author page type is provided', () => {
+    describe('when global content is provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'author';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: {
+          authors: [
+            {
+              byline: 'John Doe',
+              bio: 'John Doe is an author',
+            },
+          ],
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+
+      it('should have a title tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find('title').childAt(0).text()).toEqual('John Doe - The Sun');
+      });
+
+      it('should have an author description meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='description']").props().content).toBe('John Doe is an author');
+      });
+
+      it('should have an author og:title meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('John Doe - The Sun');
+      });
+    });
+    describe('when global content is not provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'author';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: null,
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+      });
+
+      it('should have an author og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
+      });
+    });
+    describe('when custom tags are provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'author';
+        }
+        if (prop === 'description') {
+          return 'this is a custom description';
+        }
+        if (prop === 'og:title') {
+          return 'this is a custom og:title';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: {
+          authors: [
+            {
+              byline: 'John Doe',
+              bio: 'John Doe is an author',
+            },
+          ],
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom og:title - The Sun');
+      });
+
+      it('should have an author description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
+      });
+
+      it('should have an author og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
+      });
+    });
+  });
+
+  describe('when a tag page type is provided', () => {
+    describe('when global content is provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'tag';
+        }
+        return null;
+      };
+
+      const useFusionContext = {
+        globalContent: {
+          Payload: [
+            {
+              description: 'this is a tag description',
+              name: 'tag name',
+            },
+          ],
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+
+      it('should have a title tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find('title').childAt(0).text()).toEqual('tag name - The Sun');
+      });
+
+      it('should have a tag description meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a tag description');
+      });
+
+      it('should have a tag og:title meta tag', () => {
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterSite={twitterSite}
+          websiteName={websiteName}
+        />);
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('tag name - The Sun');
+      });
+    });
+
+    describe('when global content is not provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'tag';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: null,
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+      });
+
+      it('should not have a tag description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").length).toBe(0);
+      });
+
+      it('should have a tag og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
+      });
+    });
+
+    describe('when custom tags are provided', () => {
+      const metaValue = (prop): string | null => {
+        if (prop === 'page-type') {
+          return 'tag';
+        }
+        if (prop === 'description') {
+          return 'this is a custom description';
+        }
+        if (prop === 'og:title') {
+          return 'this is a custom og:title';
+        }
+        return null;
+      };
+      const useFusionContext = {
+        globalContent: {
+          Payload: [
+            {
+              description: 'this is a tag description',
+              name: 'tag name',
+            },
+          ],
+        },
+        arcSite: 'the-sun',
+      };
+      const { globalContent, arcSite } = useFusionContext;
+      const {
+        websiteName, twitterSite,
+      } = getProperties(arcSite);
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterSite={twitterSite}
+        websiteName={websiteName}
+      />);
+
+      it('should have a title tag', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom og:title - The Sun');
+      });
+
+      it('should have a tag description meta tag', () => {
+        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
+      });
+
+      it('should have a tag og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
+      });
+    });
+  });
+});

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -39,11 +39,9 @@ interface Props {
     MetaTag: Function;
     MetaTags: Function;
     metaValue: Function;
-    getImgURL: Function;
-    getImgAlt: Function;
     globalContent?: {
         description?: {
-            basic: string;
+            basic?: string;
         };
         headlines?: {
             basic?: string;
@@ -62,13 +60,13 @@ interface Props {
             description?: string;
             name?: string;
         }>;
-    };
-    websiteName: string;
-    twitterSite: string;
+    } | null;
+    websiteName?: string | null;
+    twitterSite?: string | null;
 }
 
 const MetaData: React.FC<Props> = ({
-  MetaTag, MetaTags, metaValue, getImgURL, getImgAlt, globalContent: gc, websiteName, twitterSite,
+  MetaTag, MetaTags, metaValue, globalContent: gc, websiteName, twitterSite,
 }) => {
   const pageType = metaValue('page-type') || '';
 
@@ -77,6 +75,8 @@ const MetaData: React.FC<Props> = ({
   let authorMetaDataTags = null;
   let searchMetaDataTags = null;
 
+  // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
+  const { getImgURL, getImgAlt } = require('./promoImageHelper');
   const metaData = {
     description: null,
     keywords: null,
@@ -99,7 +99,6 @@ const MetaData: React.FC<Props> = ({
         description = gc.description.basic;
         headline = gc.headlines.basic;
       }
-
       if (metaValue('title')) {
         metaData.title = `${metaValue('title')} – ${websiteName}`;
       } else if (headline) {
@@ -150,7 +149,7 @@ const MetaData: React.FC<Props> = ({
       );
     }
   } else if (pageType === 'author') {
-    const author = (gc.authors && gc.authors.length) ? gc.authors[0] : {};
+    const author = (gc && gc.authors && gc.authors.length) ? gc.authors[0] : {};
     metaData.description = metaValue('description') || author.bio || null;
     metaData.ogTitle = metaValue('og:title') || author.byline || '';
     if (metaData.ogTitle === '') {
@@ -180,7 +179,7 @@ const MetaData: React.FC<Props> = ({
       </>
     );
   } else if (pageType === 'tag') {
-    const payload = (gc.Payload && gc.Payload.length) ? gc.Payload[0] : {};
+    const payload = (gc && gc.Payload && gc.Payload.length) ? gc.Payload[0] : {};
     metaData.description = metaValue('description') || payload.description || null;
     metaData.ogTitle = metaValue('og:title') || payload.name || '';
     if (metaData.ogTitle === '') {

--- a/src/components/MetaData/promoImageHelper.ts
+++ b/src/components/MetaData/promoImageHelper.ts
@@ -1,0 +1,49 @@
+import { resizerURL, resizerKey } from 'fusion:environment';
+
+export const getImgURL = (metaValue, metaType = 'og:image', globalContent): string => {
+  const buildURL = (_url): string | null => {
+    if (typeof window === 'undefined') {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
+      const Thumbor = require('thumbor-lite');
+      const thumbor = new Thumbor(resizerKey, resizerURL);
+      let imgSrc = _url.replace(/^http[s]?:\/\//, '')
+        .replace(' ', '%20');
+      if (imgSrc.includes('?')) {
+        imgSrc = imgSrc.replace('?', '%3F');
+      }
+
+      return thumbor.setImagePath(imgSrc)
+        .resize(1200, 630)
+        .buildUrl();
+    }
+    return null;
+  };
+
+  if (metaValue(metaType)) {
+    return buildURL(metaValue(metaType));
+  }
+
+  if (globalContent && globalContent.promo_items
+    && globalContent.promo_items.basic
+    && globalContent.promo_items.basic.url) {
+    return buildURL(globalContent.promo_items.basic.url);
+  }
+
+  return '';
+};
+
+export const getImgAlt = (metaValue, metaType = 'og:image:alt', globalContent): string | null => {
+  if (metaValue(metaType)) {
+    return metaValue(metaType);
+  }
+
+  if (globalContent && globalContent.promo_items
+    && globalContent.promo_items.basic
+    && globalContent.promo_items.basic.alt_text) {
+    if (globalContent.promo_items.basic.alt_text) {
+      return globalContent.promo_items.basic.alt_text;
+    }
+  }
+
+  return null;
+};

--- a/types/fusion.d.ts
+++ b/types/fusion.d.ts
@@ -7,6 +7,8 @@ declare module 'fusion:static' {
 
 declare module 'fusion:context';
 
+declare module 'fusion:properties';
+
 declare module 'fusion:themes';
 
 declare const Fusion: {


### PR DESCRIPTION
Sorry this is sort of a crappy PR as the initial release was already published before I figured out local engine-sdk testing....so please consider these three files in their entirety:

src/components/MetaData/index.tsx
src/components/MetaData/index.test.tsx
src/components/MetaData/promoImageHelper.ts