### PR TITLE
PEN-1068: Gallery tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.0.1-beta.4",
+  "version": "2.0.1-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.0.1-beta.4",
+  "version": "2.0.1-beta.5",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -534,8 +534,8 @@ describe('the gallery block', () => {
   describe('the "expandPhrase" prop', () => {
     describe('when the prop is provided', () => {
       it('should set the phrase text to the passed in string', () => {
-        const wrapper = mount(<Gallery galleryElements={mockGallery} expandPhrase="Bygga ut" />);
-        expect(wrapper.find('styled__ControlsButton').at(0).find('styled__PlaybackText').text()).toEqual('Bygga ut');
+        const wrapper = mount(<Gallery galleryElements={mockGallery} expandPhrase="Förstora" />);
+        expect(wrapper.find('styled__ControlsButton').at(0).find('styled__PlaybackText').text()).toEqual('Förstora');
       });
     });
 
@@ -550,8 +550,8 @@ describe('the gallery block', () => {
   describe('the "autoplayPhrase" prop', () => {
     describe('when the prop is provided', () => {
       it('should set the phrase text to the passed in string', () => {
-        const wrapper = mount(<Gallery galleryElements={mockGallery} autoplayPhrase="Autospela" />);
-        expect(wrapper.find('styled__ControlsButton').at(1).find('styled__PlaybackText').text()).toEqual('Autospela');
+        const wrapper = mount(<Gallery galleryElements={mockGallery} autoplayPhrase="Spela upp" />);
+        expect(wrapper.find('styled__ControlsButton').at(1).find('styled__PlaybackText').text()).toEqual('Spela upp');
       });
     });
 


### PR DESCRIPTION
Goes with [https://github.com/WPMedia/fusion-news-theme-blocks/pull/342](url) to update translation gallery tests