### PR TITLE
PEN-1120: Engine SDK ALC Deployment

### DIFF
--- a/stories/AIntro.stories.mdx
+++ b/stories/AIntro.stories.mdx
@@ -106,3 +106,13 @@ You can test Engine SDK components locally by adding the following properties to
 ### **Resources**
 
 - [Read more about dist tags via npm.](https://docs.npmjs.com/adding-dist-tags-to-packages)
+
+## Deploy to ALC
+
+Engine SDK documentation is available [here](https://staging.arcpublishing.com/alc/docs/storybooks/engine-theme-sdk/?path=/story/intro--page). To update the documentation on Arc Learning Center you have to upload it to S3 by following these steps:
+1. Run `npm run build-storybook` on `engine-theme-sdk`. This will generate a static storybook build in `/storybook-static`.
+2. Open the [WP-ARC AWS Console](https://console.aws.amazon.com/s3/buckets/arc-learning-center-static/docs/?region=us-east-1&tab=overview#) (you might need to authenticate with OKTA first).
+3. Go to `storybooks`, then `engine-theme-sdk` and click on `Upload`.
+4. Upload your files to replace the contents of `engine-theme-sdk` with your new build. Make sure to include the `sb_dll` folder generated in the build.
+5. Click on `Next` and go through the uploading process with the default settings.
+6. After a minute your changes will be live on [ALC](https://staging.arcpublishing.com/alc/docs/storybooks/engine-theme-sdk/?path=/story/intro--page).


### PR DESCRIPTION
Documented process for deploying Engine SDK docs to Arc Learning Center.
[Jira ticket](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&modal=detail&selectedIssue=PEN-1120)