### PR TITLE
PEN-996 update twitter metatada

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -93,9 +93,6 @@ describe('the meta data ', () => {
       expect(wrapper.find('meta').length).toBe(9);
     });
 
-    it('should have twitter tags', () => {
-      expectTwitterMeta(wrapper);
-    });
   });
 
   describe('when a video page type is provided', () => {
@@ -175,10 +172,6 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
 
     describe('when global content is not provided', () => {
@@ -230,10 +223,6 @@ describe('the meta data ', () => {
 
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
 
@@ -320,10 +309,6 @@ describe('the meta data ', () => {
 
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
   });
@@ -405,10 +390,6 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
 
     describe('when global content is not provided', () => {
@@ -460,10 +441,6 @@ describe('the meta data ', () => {
 
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
 
@@ -550,10 +527,6 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
   });
 
@@ -598,10 +571,6 @@ describe('the meta data ', () => {
       it('should have an author og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('John Doe - The Sun');
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
 
     describe('when global content is not provided', () => {
@@ -633,10 +602,6 @@ describe('the meta data ', () => {
 
       it('should have an author og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
 
@@ -686,10 +651,6 @@ describe('the meta data ', () => {
 
       it('should have an author og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
   });
@@ -736,10 +697,6 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('tag name - The Sun');
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
 
     describe('when global content is not provided', () => {
@@ -775,10 +732,6 @@ describe('the meta data ', () => {
 
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
 
@@ -829,10 +782,6 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
   });
 
@@ -873,10 +822,6 @@ describe('the meta data ', () => {
       it('should have a section og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
 
     describe('when global content is not provided', () => {
@@ -912,10 +857,6 @@ describe('the meta data ', () => {
 
       it('should have a section og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
 
@@ -970,10 +911,6 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
       });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
-      });
     });
 
     describe('when metadata fields in global content are provided', () => {
@@ -1017,10 +954,6 @@ describe('the meta data ', () => {
 
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
-      });
-
-      it('should have twitter tags', () => {
-        expectTwitterMeta(wrapper);
       });
     });
   });
@@ -1067,6 +1000,20 @@ describe('the meta data ', () => {
       arcSite: 'the-sun',
     };
     const { globalContent } = useFusionContext;
+
+    it('should have twitter tags', () => {
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
+
+      expectTwitterMeta(wrapper);
+    });
 
     it('must not have an empty twitter:site metatag if twitterUsername missing', () => {
       const wrapper = shallow(<MetaData

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -5,7 +5,7 @@
  * @jest-environment node
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 import MetaData from './index';
 
 jest.mock('react-dom/server', () => ({
@@ -22,9 +22,19 @@ const websiteName = 'The Sun';
 const twitterUsername = 'the-sun';
 const resizerURL = 'https://fake.cdn.com/resizer';
 
+const expectTwitterMeta = (wrapper: ShallowWrapper): void => {
+  expect(wrapper.find("meta[property='twitter:site']").props().content).toBe(`@${twitterUsername}`);
+  expect(wrapper.find("meta[property='twitter:card']").props().content).toBe('summary_large_image');
+};
+
+const expectTwitterMetaMissing = (wrapper: ShallowWrapper): void => {
+  expect(wrapper.find("meta[property='twitter:site']").length).toBe(0);
+  expect(wrapper.find("meta[property='twitter:card']").props().content).toBe('summary_large_image');
+};
+
 describe('the meta data ', () => {
   describe('if page type is article', () => {
-    const metaValue = (prop): string | null => {
+    const metaValue = (prop: string): string | null => {
       if (prop === 'page-type') {
         return 'article';
       }
@@ -65,7 +75,6 @@ describe('the meta data ', () => {
       arcSite: 'the-sun',
     };
     const { globalContent } = useFusionContext;
-
     const wrapper = shallow(<MetaData
       metaValue={metaValue}
       MetaTag={jest.fn()}
@@ -75,6 +84,7 @@ describe('the meta data ', () => {
       websiteName={websiteName}
       resizerURL={resizerURL}
     />);
+
     it('should have a title', () => {
       expect(wrapper.find('title').length).toBe(1);
     });
@@ -82,10 +92,15 @@ describe('the meta data ', () => {
     it('should have meta tags', () => {
       expect(wrapper.find('meta').length).toBe(9);
     });
+
+    it('should have twitter tags', () => {
+      expectTwitterMeta(wrapper);
+    });
   });
+
   describe('when a video page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'video';
         }
@@ -160,10 +175,14 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'video';
         }
@@ -212,10 +231,14 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when custom tags are provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'video';
         }
@@ -298,12 +321,16 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
   });
 
   describe('when a gallery page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'gallery';
         }
@@ -378,10 +405,14 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'gallery';
         }
@@ -430,10 +461,14 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when custom tags are provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'gallery';
         }
@@ -515,12 +550,16 @@ describe('the meta data ', () => {
       it('should not have a robots meta tag', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
   });
 
   describe('when an author page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'author';
         }
@@ -559,10 +598,14 @@ describe('the meta data ', () => {
       it('should have an author og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('John Doe - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'author';
         }
@@ -591,10 +634,14 @@ describe('the meta data ', () => {
       it('should have an author og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when custom tags are provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'author';
         }
@@ -640,12 +687,16 @@ describe('the meta data ', () => {
       it('should have an author og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
   });
 
   describe('when a tag page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'tag';
         }
@@ -685,10 +736,14 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('tag name - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'tag';
         }
@@ -721,10 +776,14 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when custom tags are provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'tag';
         }
@@ -770,12 +829,16 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
   });
 
   describe('when a section page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'section';
         }
@@ -810,10 +873,14 @@ describe('the meta data ', () => {
       it('should have a section og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'section';
         }
@@ -846,10 +913,14 @@ describe('the meta data ', () => {
       it('should have a section og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when custom tags are provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'section';
         }
@@ -899,10 +970,14 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
     });
 
     describe('when metadata fields in global content are provided', () => {
-      const metaValue = (prop): string | null => {
+      const metaValue = (prop: string): string | null => {
         if (prop === 'page-type') {
           return 'section';
         }
@@ -943,6 +1018,81 @@ describe('the meta data ', () => {
       it('should have a tag og:title meta tag', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
       });
+
+      it('should have twitter tags', () => {
+        expectTwitterMeta(wrapper);
+      });
+    });
+  });
+
+  describe('twitter meta', () => {
+    const metaValue = (prop: string): string | null => {
+      if (prop === 'page-type') {
+        return 'article';
+      }
+      if (prop === 'title') {
+        return 'the-sun';
+      }
+      return null;
+    };
+
+    const useFusionContext = {
+      globalContent: {
+        description: {
+          basic: 'this is a description',
+        },
+        headlines: {
+          basic: 'this is a headline',
+        },
+        taxonomy: {
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          seo_keywords: [
+            'keyword1',
+            'keyword2',
+          ],
+          tags: [
+            { slug: 'tag1' },
+            { slug: 'tag2' },
+          ],
+        },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        promo_items: {
+          basic: {
+            url: 'awesome-url',
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            alt_text: 'alt text',
+          },
+        },
+      },
+      arcSite: 'the-sun',
+    };
+    const { globalContent } = useFusionContext;
+
+    it('must not have an empty twitter:site metatag if twitterUsername missing', () => {
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
+
+      expectTwitterMetaMissing(wrapper);
+    });
+
+    it('must not have an empty twitter:site metatag if twitterUsername empty', () => {
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername=""
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
+
+      expectTwitterMetaMissing(wrapper);
     });
   });
 });

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -14,12 +14,12 @@ jest.mock('react-dom/server', () => ({
 
 // getProperties.mockImplementation(() => ({
 //   websiteName: 'The Sun',
-//   twitterSite: 'https://www.twitter.com/the-sun',
+//   twitterUsername: 'the-sun',
 //   dangerouslyInjectJS: [],
 // }));
 
 const websiteName = 'The Sun';
-const twitterSite = 'https://www.twitter.com/the-sun';
+const twitterUsername = 'the-sun';
 const resizerURL = 'https://fake.cdn.com/resizer';
 
 describe('the meta data ', () => {
@@ -71,7 +71,7 @@ describe('the meta data ', () => {
       MetaTag={jest.fn()}
       MetaTags={jest.fn()}
       globalContent={globalContent}
-      twitterSite={twitterSite}
+      twitterUsername={twitterUsername}
       websiteName={websiteName}
       resizerURL={resizerURL}
     />);
@@ -130,7 +130,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -143,7 +143,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -156,7 +156,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -169,7 +169,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -182,7 +182,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -195,7 +195,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -208,7 +208,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -233,7 +233,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -319,7 +319,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -399,7 +399,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -412,7 +412,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -425,7 +425,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -438,7 +438,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -451,7 +451,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -464,7 +464,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -477,7 +477,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -503,7 +503,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -588,7 +588,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -649,7 +649,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -662,7 +662,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -675,7 +675,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -700,7 +700,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -744,7 +744,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -791,7 +791,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -804,7 +804,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -817,7 +817,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -843,7 +843,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -892,7 +892,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -933,7 +933,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -946,7 +946,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -959,7 +959,7 @@ describe('the meta data ', () => {
           MetaTag={jest.fn()}
           MetaTags={jest.fn()}
           globalContent={globalContent}
-          twitterSite={twitterSite}
+          twitterUsername={twitterUsername}
           websiteName={websiteName}
           resizerURL={resizerURL}
         />);
@@ -985,7 +985,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -1038,7 +1038,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -1082,7 +1082,7 @@ describe('the meta data ', () => {
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
         globalContent={globalContent}
-        twitterSite={twitterSite}
+        twitterUsername={twitterUsername}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -123,98 +123,45 @@ describe('the meta data ', () => {
         arcSite: 'the-sun',
       };
       const { globalContent } = useFusionContext;
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
 
       it('should have a title tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find('title').childAt(0).text()).toEqual('this is a video headline – The Sun');
       });
 
       it('should have a video description meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='description']").props().content).toBe('this is a video description');
       });
 
       it('should have a video keywords meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='keywords']").props().content).toBe('keyword1,keyword2');
       });
 
       it('should have a video og:title meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a video headline');
       });
 
       it('should have a video og:image meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:image']").props().content).toBe('https://fake.cdn.com/resizer/l_1yxKdAU0rtnyaww9LofnGAFkw=/1200x630/awesome-url');
       });
 
       it('should have a video og:image:alt meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:image:alt']").props().content).toBe('alt text');
       });
 
       it('should not have a robots meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
     });
+
     describe('when global content is not provided', () => {
       const metaValue = (prop): string | null => {
         if (prop === 'page-type') {
@@ -266,6 +213,7 @@ describe('the meta data ', () => {
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
     });
+
     describe('when custom tags are provided', () => {
       const metaValue = (prop): string | null => {
         if (prop === 'page-type') {
@@ -352,6 +300,7 @@ describe('the meta data ', () => {
       });
     });
   });
+
   describe('when a gallery page type is provided', () => {
     describe('when global content is provided', () => {
       const metaValue = (prop): string | null => {
@@ -392,95 +341,41 @@ describe('the meta data ', () => {
         arcSite: 'the-sun',
       };
       const { globalContent } = useFusionContext;
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
 
       it('should have a title tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find('title').childAt(0).text()).toEqual('this is a gallery headline – The Sun');
       });
 
       it('should have a gallery description meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='description']").props().content).toBe('this is a gallery description');
       });
 
       it('should have a gallery keywords meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='keywords']").props().content).toBe('keyword1,keyword2');
       });
 
       it('should have a gallery og:title meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a gallery headline');
       });
 
       it('should have a gallery og:image meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:image']").props().content).toBe('https://fake.cdn.com/resizer/l_1yxKdAU0rtnyaww9LofnGAFkw=/1200x630/awesome-url');
       });
 
       it('should have a gallery og:image:alt meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:image:alt']").props().content).toBe('alt text');
       });
 
       it('should not have a robots meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
     });
@@ -622,6 +517,7 @@ describe('the meta data ', () => {
       });
     });
   });
+
   describe('when an author page type is provided', () => {
     describe('when global content is provided', () => {
       const metaValue = (prop): string | null => {
@@ -642,46 +538,29 @@ describe('the meta data ', () => {
         arcSite: 'the-sun',
       };
       const { globalContent } = useFusionContext;
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
 
       it('should have a title tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find('title').childAt(0).text()).toEqual('John Doe - The Sun');
       });
 
       it('should have an author description meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='description']").props().content).toBe('John Doe is an author');
       });
 
       it('should have an author og:title meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('John Doe - The Sun');
       });
     });
+
     describe('when global content is not provided', () => {
       const metaValue = (prop): string | null => {
         if (prop === 'page-type') {
@@ -713,6 +592,7 @@ describe('the meta data ', () => {
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
       });
     });
+
     describe('when custom tags are provided', () => {
       const metaValue = (prop): string | null => {
         if (prop === 'page-type') {
@@ -784,43 +664,25 @@ describe('the meta data ', () => {
         arcSite: 'the-sun',
       };
       const { globalContent } = useFusionContext;
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
 
       it('should have a title tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find('title').childAt(0).text()).toEqual('tag name - The Sun');
       });
 
       it('should have a tag description meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='description']").props().content).toBe('this is a tag description');
       });
 
       it('should have a tag og:title meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('tag name - The Sun');
       });
     });
@@ -910,6 +772,7 @@ describe('the meta data ', () => {
       });
     });
   });
+
   describe('when a section page type is provided', () => {
     describe('when global content is provided', () => {
       const metaValue = (prop): string | null => {
@@ -926,43 +789,25 @@ describe('the meta data ', () => {
         arcSite: 'the-sun',
       };
       const { globalContent } = useFusionContext;
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
 
       it('should have a title tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find('title').childAt(0).text()).toEqual('Entertainment - The Sun');
       });
 
       it('should not have a section description meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[name='description']").length).toBe(0);
       });
 
       it('should have a section og:title meta tag', () => {
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
         expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
       });
     });

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -69,12 +69,12 @@ interface Props {
     };
   } | null;
   websiteName?: string | null;
-  twitterSite?: string | null;
+  twitterUsername?: string | null;
   resizerURL?: string | null;
 }
 
 const MetaData: React.FC<Props> = ({
-  MetaTag, MetaTags, metaValue, globalContent: gc, websiteName, twitterSite, resizerURL,
+  MetaTag, MetaTags, metaValue, globalContent: gc, websiteName, twitterUsername, resizerURL,
 }) => {
   const pageType = metaValue('page-type') || '';
 
@@ -95,7 +95,7 @@ const MetaData: React.FC<Props> = ({
     title: websiteName,
     ogTitle: websiteName,
     ogSiteName: websiteName,
-    twitterSite: twitterSite ? `@${twitterSite}` : null,
+    twitterUsername: twitterUsername ? `@${twitterUsername}` : null,
     twitterCard: 'summary_large_image',
   };
 
@@ -253,8 +253,8 @@ const MetaData: React.FC<Props> = ({
         && <meta property="og:site_name" content={metaData.ogSiteName} />
       }
       {
-        metaData.twitterSite
-        && <meta property="twitter:site" content={metaData.twitterSite} />
+        metaData.twitterUsername
+        && <meta property="twitter:site" content={metaData.twitterUsername} />
       }
       {
         metaData.twitterCard
@@ -312,7 +312,7 @@ MetaData.propTypes = {
   /** The name of the website */
   websiteName: PropTypes.string,
   /** The corresponding twitter site name */
-  twitterSite: PropTypes.string,
+  twitterUsername: PropTypes.string,
 };
 
 export default MetaData;


### PR DESCRIPTION
[PEN-996](https://arcpublishing.atlassian.net/browse/PEN-996)

- Updated the twitter property name used to get the twitter handle from the site properties
- updated tests
