### PR TITLE
Add role for arc logo

### DIFF
--- a/src/components/ArcLogo/index.tsx
+++ b/src/components/ArcLogo/index.tsx
@@ -9,7 +9,7 @@ interface LogoProps {
 const ArcLogo: React.FC<LogoProps> = ({
   title = 'Arc Publishing logo', description = '',
 }) => (
-  <svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img">
     <title>{title}</title>
     <desc>{description}</desc>
     <defs>


### PR DESCRIPTION
To Test: 

`npm run storybook` 
-> navigate to accessibility tab

before: 
see
#43 

after (a11y):

<img width="834" alt="Screen Shot 2020-07-10 at 5 09 34 PM" src="https://user-images.githubusercontent.com/5950956/87206910-336d2b00-c2d0-11ea-961b-2a9deccac6f1.png">
