### PR TITLE
PEN-1137: Make Engine Theme SDK public

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,10 @@
+Shield: [![CC BY-NC-ND 4.0][cc-by-shield]][cc-by-nc-nd]
+
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License][cc-by-nc-nd].
+
+[![CC BY-NC-ND 4.0][cc-by-image]][cc-by-nc-nd]
+
+[cc-by-nc-nd]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+[cc-by-image]: https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg

--- a/README.md
+++ b/README.md
@@ -49,4 +49,13 @@ In the future, this will be hosted. To build, see [documentation](https://storyb
 
 ## License
 
-TODO
+Shield: [![CC BY-NC-ND 4.0][cc-by-shield]][cc-by-nc-nd]
+
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License][cc-by-nc-nd].
+
+[![CC BY-NC-ND 4.0][cc-by-image]][cc-by-nc-nd]
+
+[cc-by-nc-nd]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+[cc-by-image]: https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "access": "public"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WPMedia/engine-theme-sdk.git"
   },
   "author": "",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "bugs": {
     "url": "https://github.com/WPMedia/engine-theme-sdk/issues"
   },


### PR DESCRIPTION
- Added licenses to make Engine Theme SDK's repo public
- Same process as https://github.com/WPMedia/fusion-news-theme-blocks/pull/411