### PR TITLE
Use standardized branch names in docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Description
+_Information about what you changed for this PR_
+
+## Jira Ticket
+- [PEN-](https://arcpublishing.atlassian.net/browse/PEN-)
+
+## Acceptance Criteria
+_copy from ticket_
+
+## Test Steps
+- Add test steps a reviewer must complete to test this PR
+
+## Effect Of Changes
+### Before
+_Example: When I clicked the search button, the button turned red._
+
+[include screenshot or gif or link to video, storybook would be awesome]
+
+### After
+_Example: When I clicked the search button, the button turned green._
+
+[include screenshot or gif or link to video, storybook would be awesome]
+
+## Dependencies or Side Effects
+_Examples of dependencies or side effects are:_
+- Additional settings that will be required in the blocks.json
+- Changes to the custom fields which will require users to reconfigure features
+- Update to css framework or SDK
+- Dependency on another PR that needs to be merged first
+
+## Review Checklist
+_The author of the PR should fill out the following sections to ensure this PR is ready for review._
+- [ ] Confirmed all the test steps above are working
+- [ ] Confirmed there are no linter errors
+- [ ] Confirmed this PR has reasonable code coverage
+  - [ ] Confirmed this PR has unit test files
+  - [ ] Ran `npm test`, made sure all tests are passing
+  - [ ] If the amount of work to write unit tests for this change are excessive,
+please explain why (so that we can fix it whenever it gets refactored).
+- [ ] Confirmed relevant documentation has been updated/added.

--- a/README.md
+++ b/README.md
@@ -17,31 +17,31 @@ In the future, this will be hosted. To build, see [documentation](https://storyb
 
 ## How To Publish
 
-1. Pull the latest `staging` branch. 
+1. Pull the latest `canary` branch. 
 
-`git checkout staging`
+`git checkout canary`
 
 `git fetch -a`
 
-2. Branch off the `staging` branch
+2. Branch off the `canary` branch
 
 `git checkout -b PEN-[jira ticket num]-[brief description of feature]`
 
 3. Do the work (heh). Commit as you go, which will run the linter and tests.
 
-4. Make pull request using GitHub against the `staging` branch. Get approval for your pr on your feature branch. 
+4. Make pull request using GitHub against the `canary` branch. Get approval for your pr on your feature branch, then merge.
 
-5. Merge into `staging` branch. 
+5. When the approved work is ready to move into beta, merge into `canary` branch into the `beta` branch. 
 
 `npm version prerelease --preid=beta`
 
  `npm publish --tag beta`
 
-6. Go to new theme feature pack's `blocks.json`. Change your engine block to the @beta release in the blocks list (eg, "@wpmedia/header-nav" -> "@wpmedia/header-nav@beta"). Make a pr against the news theme repo making that change to the `master` branch. Then publish that change using deployment strategy to the staging environment (corecomponents prod is a staging env). Alert quality assurance stakeholder that the change has been published.
+6. Go to new theme feature pack's `blocks.json`. Change your engine block to the @beta release in the blocks list (eg, "@wpmedia/header-nav" -> "@wpmedia/header-nav@beta"). Make a pr against the news theme repo making that change to the `stable` branch. Then publish that change using deployment strategy to the staging environment (corecomponents prod is a staging env). Alert quality assurance stakeholder that the change has been published.
 
-7. After design qa and qa approval, make a pull request from the staging branch to the master branch. (Should we make a new pr for just your staging changes?) 
+7. After design qa and qa approval, make a pull request from the `beta` branch to the `stable` branch. (Should we make a new pr for just your staging changes?) 
 
-8. Once the pr has been approved, merge your feature staging branch to master. Then, in master, you can publish against what's changed. (This could be done at the end of a sprint.)
+8. Once the pr has been approved, merge the `beta` branch to `stable`. Then, in `stable`, you can publish against what's changed. (This could be done at the end of a sprint.)
 
 `npm publish --tag stable`
 


### PR DESCRIPTION
Updating the docs to match our branch name standardization.

[PEN-1265](https://arcpublishing.atlassian.net/browse/PEN-1265)