### PR TITLE
Use stable branch for doc deployment

### DIFF
--- a/cfn/configs/deployment.yml
+++ b/cfn/configs/deployment.yml
@@ -9,7 +9,7 @@ context:
 
     git:
       owner: WPMedia
-      branch: staging
+      branch: stable
       repo: engine-theme-sdk
 
     stages:


### PR DESCRIPTION
## Description
_This PR updates the doc deployment to the ALC based on changes that are made to the *stable* branch. This was changed from *staging*. Although staging is being deprecated in favor of "canary", I think it makes sense to update the script to stable/master since that way it only deploys on final approval and aligns with SDK deployments._

## Jira Ticket
- [PEN-1265](https://arcpublishing.atlassian.net/browse/PEN-1265)

## Acceptance Criteria
This wasn't on the ticket, but we found it so we fixed it :D 

## Test Steps
N/A

## Effect Of Changes
### Before
_On changes to the canary/dev/staging branch, docs are deployed to ALC._

### After
_On changes to the master/stable branch, docs are deployed to the ALC._

## Dependencies or Side Effects
NA

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
