### PR TITLE
PEN-1276 - fix title and description metaData tags

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -34,63 +34,250 @@ const expectTwitterMetaMissing = (wrapper: ShallowWrapper): void => {
 
 describe('the meta data ', () => {
   describe('if page type is article', () => {
-    const metaValue = (prop: string): string | null => {
-      if (prop === 'page-type') {
-        return 'article';
-      }
-      if (prop === 'title') {
-        return 'the-sun';
-      }
-      return null;
-    };
+    describe('when globalContent is complete', () => {
+      const metaValue = (prop: string): string | null => {
+        if (prop === 'page-type') {
+          return 'article';
+        }
+        if (prop === 'title') {
+          return 'the-sun';
+        }
+        return null;
+      };
 
-    const useFusionContext = {
-      globalContent: {
-        description: {
-          basic: 'this is a description',
-        },
-        headlines: {
-          basic: 'this is a headline',
-        },
-        taxonomy: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          seo_keywords: [
-            'keyword1',
-            'keyword2',
-          ],
-          tags: [
-            { slug: 'tag1' },
-            { slug: 'tag2' },
-          ],
-        },
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        promo_items: {
-          basic: {
-            url: 'awesome-url',
+      const useFusionContext = {
+        globalContent: {
+          description: {
+            basic: 'this is a description',
+          },
+          headlines: {
+            basic: 'this is a headline',
+          },
+          taxonomy: {
             // eslint-disable-next-line @typescript-eslint/camelcase
-            alt_text: 'alt text',
+            seo_keywords: [
+              'keyword1',
+              'keyword2',
+            ],
+            tags: [
+              { slug: 'tag1' },
+              { slug: 'tag2' },
+            ],
+          },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          promo_items: {
+            basic: {
+              url: 'awesome-url',
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              alt_text: 'alt text',
+            },
           },
         },
-      },
-      arcSite: 'the-sun',
-    };
-    const { globalContent } = useFusionContext;
-    const wrapper = shallow(<MetaData
-      metaValue={metaValue}
-      MetaTag={jest.fn()}
-      MetaTags={jest.fn()}
-      globalContent={globalContent}
-      twitterUsername={twitterUsername}
-      websiteName={websiteName}
-      resizerURL={resizerURL}
-    />);
+        arcSite: 'the-sun',
+      };
+      const { globalContent } = useFusionContext;
+      const wrapper = shallow(<MetaData
+        metaValue={metaValue}
+        MetaTag={jest.fn()}
+        MetaTags={jest.fn()}
+        globalContent={globalContent}
+        twitterUsername={twitterUsername}
+        websiteName={websiteName}
+        resizerURL={resizerURL}
+      />);
 
-    it('should have a title', () => {
-      expect(wrapper.find('title').length).toBe(1);
+      it('should have a title', () => {
+        expect(wrapper.find('title').length).toBe(1);
+      });
+
+      it('should have meta tags', () => {
+        expect(wrapper.find('meta').length).toBe(9);
+      });
     });
 
-    it('should have meta tags', () => {
-      expect(wrapper.find('meta').length).toBe(9);
+    describe('when need to add a description tag', () => {
+      it('must use the meta value first', () => {
+        const metaValue = (prop: string): string | null => {
+          if (prop === 'page-type') {
+            return 'article';
+          }
+          if (prop === 'title') {
+            return 'the-sun';
+          }
+          if (prop === 'description') {
+            return 'description from metaValue';
+          }
+          return null;
+        };
+
+        const useFusionContext = {
+          globalContent: {
+            description: {
+              basic: 'this is a description',
+            },
+          },
+          arcSite: 'the-sun',
+        };
+        const { globalContent } = useFusionContext;
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterUsername={twitterUsername}
+          websiteName={websiteName}
+          resizerURL={resizerURL}
+        />);
+        expect(wrapper.find("meta[name='description']").prop('content')).toEqual(metaValue('description'));
+      });
+
+      it('must use the global content if metaValue missing', () => {
+        const metaValue = (prop: string): string | null => {
+          if (prop === 'page-type') {
+            return 'article';
+          }
+          if (prop === 'title') {
+            return 'the-sun';
+          }
+          return null;
+        };
+
+        const useFusionContext = {
+          globalContent: {
+            description: {
+              basic: 'this is a description',
+            },
+          },
+          arcSite: 'the-sun',
+        };
+        const { globalContent } = useFusionContext;
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterUsername={twitterUsername}
+          websiteName={websiteName}
+          resizerURL={resizerURL}
+        />);
+        expect(wrapper.find("meta[name='description']").prop('content')).toEqual(globalContent.description.basic);
+      });
+
+      it('must not render a description if found no valid values', () => {
+        const metaValue = (prop: string): string | null => {
+          if (prop === 'page-type') {
+            return 'article';
+          }
+          if (prop === 'title') {
+            return 'the-sun';
+          }
+          return null;
+        };
+
+        const useFusionContext = {
+          globalContent: {},
+          arcSite: 'the-sun',
+        };
+        const { globalContent } = useFusionContext;
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterUsername={twitterUsername}
+          websiteName={websiteName}
+          resizerURL={resizerURL}
+        />);
+        expect(wrapper.find("meta[name='description']").length).toBe(0);
+      });
+    });
+
+    describe('when need to add a title tag', () => {
+      it('must use the metaValue first and append the websiteName', () => {
+        const metaValue = (prop: string): string | null => {
+          if (prop === 'page-type') {
+            return 'article';
+          }
+          if (prop === 'title') {
+            return 'title from metaValue';
+          }
+          return null;
+        };
+
+        const useFusionContext = {
+          globalContent: {
+            headlines: {
+              basic: 'this is a headline',
+            },
+          },
+          arcSite: 'the-sun',
+        };
+        const { globalContent } = useFusionContext;
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterUsername={twitterUsername}
+          websiteName={websiteName}
+          resizerURL={resizerURL}
+        />);
+        expect(wrapper.find('title').text()).toEqual(`${metaValue('title')} – ${websiteName}`);
+      });
+
+      it('must use the headlines story if metaValue missing and append the websiteName', () => {
+        const metaValue = (prop: string): string | null => {
+          if (prop === 'page-type') {
+            return 'article';
+          }
+          return null;
+        };
+
+        const useFusionContext = {
+          globalContent: {
+            headlines: {
+              basic: 'this is a headline',
+            },
+          },
+          arcSite: 'the-sun',
+        };
+        const { globalContent } = useFusionContext;
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterUsername={twitterUsername}
+          websiteName={websiteName}
+          resizerURL={resizerURL}
+        />);
+        expect(wrapper.find('title').text()).toEqual(`${globalContent.headlines.basic} – ${websiteName}`);
+      });
+
+      it('must use the websiteName if other values not found ', () => {
+        const metaValue = (prop: string): string | null => {
+          if (prop === 'page-type') {
+            return 'article';
+          }
+          return null;
+        };
+
+        const useFusionContext = {
+          globalContent: {},
+          arcSite: 'the-sun',
+        };
+        const { globalContent } = useFusionContext;
+        const wrapper = shallow(<MetaData
+          metaValue={metaValue}
+          MetaTag={jest.fn()}
+          MetaTags={jest.fn()}
+          globalContent={globalContent}
+          twitterUsername={twitterUsername}
+          websiteName={websiteName}
+          resizerURL={resizerURL}
+        />);
+        expect(wrapper.find('title').text()).toEqual(websiteName);
+      });
     });
   });
 

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -101,13 +101,9 @@ const MetaData: React.FC<Props> = ({
 
   if (pageType === 'article' || pageType === 'video' || pageType === 'gallery') {
     if (typeof window === 'undefined') {
-      let description = null;
-      let headline = null;
+      const description = gc && gc.description && gc.description.basic;
+      const headline = gc && gc.headlines && gc.headlines.basic;
 
-      if (gc && gc.description && gc.headlines) {
-        description = gc.description.basic;
-        headline = gc.headlines.basic;
-      }
       if (metaValue('title')) {
         metaData.title = `${metaValue('title')} – ${websiteName}`;
       } else if (headline) {


### PR DESCRIPTION
## Description
updated the logic on how the Title and Description tags are rendered. 
removed the dependency that both must be present to be the initial value assigned.

## Jira Ticket
- [PEN-1276](https://arcpublishing.atlassian.net/browse/PEN-1276)

## Acceptance Criteria
* The metadata title and metadata description should appear if either of them are present. Both should not have to be present for one to appear.

## Test Steps
- use an story with description and metaValue, the metaValue must be used as description.
- use an story with description and without metaValue, the description will be rendered
- use an story without description and metavalue, no description must be present
- use an story and add a metaValue, must generate the title tag like `$metaValue + $websiteName`
- use an story and add not use a metaValue, must generate the title tag like `$headline + $websiteName`
- an story without headline or metaValue, must generate a title tag like `$websiteName`

## Dependencies or Side Effects
- none

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
