### PR TITLE
PEN-1303 update social tags support

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -18,1186 +18,1121 @@ jest.mock('react-dom/server', () => ({
 //   dangerouslyInjectJS: [],
 // }));
 
+interface MetaValuesReturnInterface {
+  (prop: string): string | null;
+}
+
+interface GlobalContentBag {
+  [x: string]: object;
+}
+
 const websiteName = 'The Sun';
+const websiteDomain = 'http://example.com';
 const twitterUsername = 'the-sun';
 const resizerURL = 'https://fake.cdn.com/resizer';
+const arcSite = 'the-sun';
+const facebookAdmins = '1111111111';
+const globalContentComplete = {
+  description: {
+    basic: 'this is a description',
+  },
+  headlines: {
+    basic: 'this is a headline',
+  },
+  taxonomy: {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    seo_keywords: [
+      'keyword1',
+      'keyword2',
+    ],
+    tags: [
+      { slug: 'tag1' },
+      { slug: 'tag2' },
+    ],
+  },
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  promo_items: {
+    basic: {
+      url: 'awesome-url',
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      alt_text: 'alt text',
+    },
+  },
+  websites: {
+    'the-sun': {
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      website_url: '/url/to/story/',
+    },
+  },
+  authors: [
+    {
+      byline: 'John Doe',
+      bio: 'John Doe is an author',
+    },
+  ],
+  Payload: [
+    {
+      name: 'payload name',
+      description: 'payload description',
+    },
+  ],
+  name: 'section name',
+  metadata: {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    metadata_description: 'metadata section description',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    metadata_title: 'metadata section title',
+  },
+};
 
 const expectTwitterMeta = (wrapper: ShallowWrapper): void => {
-  expect(wrapper.find("meta[property='twitter:site']").props().content).toBe(`@${twitterUsername}`);
-  expect(wrapper.find("meta[property='twitter:card']").props().content).toBe('summary_large_image');
+  expect(wrapper.find("meta[name='twitter:site']").props().content).toBe(`@${twitterUsername}`);
+  expect(wrapper.find("meta[name='twitter:card']").props().content).toBe('summary_large_image');
 };
 
 const expectTwitterMetaMissing = (wrapper: ShallowWrapper): void => {
-  expect(wrapper.find("meta[property='twitter:site']").length).toBe(0);
-  expect(wrapper.find("meta[property='twitter:card']").props().content).toBe('summary_large_image');
+  expect(wrapper.find("meta[name='twitter:site']").length).toBe(0);
+  expect(wrapper.find("meta[name='twitter:card']").props().content).toBe('summary_large_image');
+};
+
+const wrapperGenerator = (
+  metaValue: MetaValuesReturnInterface,
+  globalContent: GlobalContentBag,
+): ShallowWrapper => (
+  shallow(
+    <MetaData
+      metaValue={metaValue}
+      MetaTag={jest.fn()}
+      MetaTags={jest.fn()}
+      globalContent={globalContent}
+      twitterUsername={twitterUsername}
+      websiteName={websiteName}
+      resizerURL={resizerURL}
+      arcSite={arcSite}
+      websiteDomain={websiteDomain}
+      facebookAdmins={facebookAdmins}
+    />,
+  )
+);
+
+const metaValues = (values: object): MetaValuesReturnInterface => {
+  const data = { ...values };
+  return (prop: string): string | null => data[prop];
+};
+
+const titleTest = (pageType: string): void => {
+  describe('when need to add a title tag', () => {
+    it('must use the meta value first and add the site name', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        title: 'meta title',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('title').text()).toEqual(`${metaValue('title')} – ${websiteName}`);
+    });
+
+    it('must use the headline if metaValue missing', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('title').text()).toEqual(`${globalContentComplete.headlines.basic} – ${websiteName}`);
+    });
+
+    it('must use the websiteName if found no valid values', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const globalContent = {
+        ...globalContentComplete,
+        headlines: {},
+      };
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find('title').text()).toEqual(websiteName);
+    });
+  });
+};
+const ogTitleTest = (pageType: string): void => {
+  describe('when need to add a og:title tag', () => {
+    it('must use the meta value first and add the site name', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        'og:title': 'og meta title',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find("meta[property='og:title']").prop('content')).toEqual(metaValue('og:title'));
+    });
+
+    it('must use the headline if metaValue missing', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find("meta[property='og:title']").prop('content')).toEqual(globalContentComplete.headlines.basic);
+    });
+
+    it('must use the websiteName if found no valid values', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const globalContent = {
+        ...globalContentComplete,
+        headlines: {},
+      };
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find("meta[property='og:title']").prop('content')).toEqual(websiteName);
+    });
+  });
+};
+const descriptionTest = (pageType: string): void => {
+  describe('when need to add a description tag', () => {
+    it('must use the meta value first', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        title: 'the-sun',
+        description: 'description from metaValue',
+      });
+
+      const globalContent = {
+        description: {
+          basic: 'this is a description',
+        },
+      };
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find("meta[name='description']").prop('content')).toEqual(metaValue('description'));
+    });
+
+    it('must use the global content if metaValue missing', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        title: 'the-sun',
+      });
+
+      const globalContent = {
+        description: {
+          basic: 'this is a description',
+        },
+      };
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find("meta[name='description']").prop('content')).toEqual(globalContent.description.basic);
+    });
+
+    it('must not render a description if found no valid values', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        title: 'the-sun',
+      });
+
+      const globalContent = {};
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find("meta[name='description']").length).toBe(0);
+    });
+  });
+};
+
+const ogImageTest = (pageType: string): void => {
+  describe('when need to add a og:image tag', () => {
+    it('must use the metaValue first', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        'og:image': 'http://example.com/resources/image.jpg',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      const content = wrapper.find("meta[property='og:image']").prop('content');
+      expect(
+        content.substring(0, resizerURL.length),
+      ).toEqual(resizerURL);
+    });
+
+    it('must use the promo_items.basic if found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      const content = wrapper.find("meta[property='og:image']").prop('content');
+      const url = globalContentComplete.promo_items.basic.url.replace('https://', '');
+      expect(
+        content.substring(0, resizerURL.length),
+      ).toEqual(resizerURL);
+      expect(
+        content.slice(url.length * -1),
+      ).toEqual(url);
+    });
+    it('must not add og:image if url not found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const globalContent = {
+        ...globalContentComplete,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        promo_items: {},
+      };
+
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+    });
+  });
+};
+
+const ogImageAltTest = (pageType: string): void => {
+  describe('when need to add a og:image:alt tag', () => {
+    it('must use the metaValue first', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        'og:image:alt': 'meta alt image description',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[property='og:image:alt']").prop('content'),
+      ).toEqual(metaValue('og:image:alt'));
+    });
+
+    it('must use the promo_images alt value', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[property='og:image:alt']").prop('content'),
+      ).toEqual(globalContentComplete.promo_items.basic.alt_text);
+    });
+
+    it('must not add og:image:alt if values not found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const content = {
+        ...globalContentComplete,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        promo_items: {},
+      };
+      const wrapper = wrapperGenerator(metaValue, content);
+      expect(
+        wrapper.find("meta[property='og:image:alt']").length,
+      ).toBe(0);
+    });
+  });
+};
+
+const twitterTitleTest = (pageType: string): void => {
+  describe('when need to add a twitter:title tag', () => {
+    it('must use the metaValue first', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        twitterTitle: 'meta alt twitter title',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[name='twitter:title']").prop('content'),
+      ).toEqual(metaValue('twitterTitle'));
+    });
+
+    it('must use the headlines if metaValue not found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[name='twitter:title']").prop('content'),
+      ).toEqual(globalContentComplete.headlines.basic);
+    });
+
+    it('must use the websiteName if no values found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const content = {
+        ...globalContentComplete,
+        headlines: {},
+      };
+      const wrapper = wrapperGenerator(metaValue, content);
+      expect(
+        wrapper.find("meta[name='twitter:title']").prop('content'),
+      ).toEqual(websiteName);
+    });
+  });
+};
+
+const twitterImageTest = (pageType: string): void => {
+  describe('when need to add a twitter:image tag', () => {
+    it('must use the metaValue first', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        'twitter:image': 'http://example.com/resources/image.jpg',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      const content = wrapper.find("meta[name='twitter:image']").prop('content');
+      expect(
+        content.substring(0, resizerURL.length),
+      ).toEqual(resizerURL);
+    });
+
+    it('must use the promo_items.basic if found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      const content = wrapper.find("meta[name='twitter:image']").prop('content');
+      const url = globalContentComplete.promo_items.basic.url.replace('https://', '');
+      expect(
+        content.substring(0, resizerURL.length),
+      ).toEqual(resizerURL);
+      expect(
+        content.slice(url.length * -1),
+      ).toEqual(url);
+    });
+
+    it('must not add twitter:image if url not found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const globalContent = {
+        ...globalContentComplete,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        promo_items: {},
+      };
+
+      const wrapper = wrapperGenerator(metaValue, globalContent);
+      expect(wrapper.find("meta[name='twitter:image']").length).toBe(0);
+    });
+  });
+};
+
+const keywordsTest = (pageType: string): void => {
+  describe('when need to add a keywords tag', () => {
+    it('must use the metaValue first', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+        keywords: 'key1, key2,key3',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find("meta[name='keywords']").prop('content')).toEqual(metaValue('keywords'));
+    });
+
+    it('must use the globalContent.taxonomy.seo_keywords if exists', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[name='keywords']").prop('content'),
+      ).toEqual(globalContentComplete.taxonomy.seo_keywords.join(','));
+    });
+
+    it('must use the globalContent.taxonomy.tags if exists', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const content = {
+        ...globalContentComplete,
+        taxonomy: {
+          tags: globalContentComplete.taxonomy.tags,
+        },
+      };
+      const wrapper = wrapperGenerator(metaValue, content);
+      const tags = content.taxonomy.tags.reduce((acc, ele) => acc.concat(ele.slug), []).join(',');
+      expect(
+        wrapper.find("meta[name='keywords']").prop('content'),
+      ).toEqual(tags);
+    });
+
+    it('must not use meta keywords if valid values not found', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const content = {
+        ...globalContentComplete,
+        taxonomy: {},
+      };
+      const wrapper = wrapperGenerator(metaValue, content);
+      expect(wrapper.find("meta[name='keywords']").length).toBe(0);
+    });
+
+    it('must not use meta keywords if tags do not have slug', () => {
+      const metaValue = metaValues({
+        'page-type': pageType,
+      });
+      const content = {
+        ...globalContentComplete,
+        taxonomy: {
+          tags: [
+            { zapato: 'tag1' },
+            { zapato: 'tag2' },
+          ],
+        },
+      };
+      const wrapper = wrapperGenerator(metaValue, content);
+      expect(wrapper.find("meta[name='keywords']").length).toBe(0);
+    });
+  });
+};
+
+const urlTest = (pageType: string): void => {
+  describe('when globalContent is provided', () => {
+    const metaValue = metaValues({
+      'page-type': pageType,
+      title: 'the-sun',
+    });
+    const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+    it('should have a og:url', () => {
+      expect(wrapper.find("meta[property='og:url']").prop('content')).toEqual('http://example.com/url/to/story/');
+    });
+  });
+};
+
+const noGlobalContent = (pageType: string): void => {
+  const metaValue = metaValues({
+    'page-type': pageType,
+  });
+  const globalContent = null;
+  const wrapper = wrapperGenerator(metaValue, globalContent);
+
+  it('should have a title tag', () => {
+    expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+  });
+
+  it('should not have a description meta tag', () => {
+    expect(wrapper.find("meta[name='description']").length).toBe(0);
+  });
+
+  it('should not have a twitter:description meta tag', () => {
+    expect(wrapper.find("meta[name='twitter:description']").length).toBe(0);
+  });
+
+  it('should not have a og:description meta tag', () => {
+    expect(wrapper.find("meta[property='og:description']").length).toBe(0);
+  });
+
+  it('should not have a keywords meta tag', () => {
+    expect(wrapper.find("meta[name='keywords']").length).toBe(0);
+  });
+
+  it('should have a og:title meta tag', () => {
+    expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
+  });
+
+  it('should have a twitter:title meta tag', () => {
+    expect(wrapper.find("meta[name='twitter:title']").props().content).toBe('The Sun');
+  });
+
+  it('should have a og:image meta tag', () => {
+    expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+  });
+
+  it('should not have a og:image:alt meta tag', () => {
+    expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
+  });
 };
 
 describe('the meta data ', () => {
-  describe('if page type is article', () => {
-    describe('when globalContent is complete', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'article';
-        }
-        if (prop === 'title') {
-          return 'the-sun';
-        }
-        return null;
-      };
+  describe('when a article page type is provided', () => {
+    describe('when globalContent is provided', () => {
+      titleTest('article');
+      descriptionTest('article');
+      ogTitleTest('article');
+      ogImageTest('article');
+      ogImageAltTest('article');
+      twitterTitleTest('article');
+      twitterImageTest('article');
+      keywordsTest('article');
+      urlTest('article');
 
-      const useFusionContext = {
-        globalContent: {
-          description: {
-            basic: 'this is a description',
-          },
-          headlines: {
-            basic: 'this is a headline',
-          },
-          taxonomy: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            seo_keywords: [
-              'keyword1',
-              'keyword2',
-            ],
-            tags: [
-              { slug: 'tag1' },
-              { slug: 'tag2' },
-            ],
-          },
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          promo_items: {
-            basic: {
-              url: 'awesome-url',
-              // eslint-disable-next-line @typescript-eslint/camelcase
-              alt_text: 'alt text',
-            },
-          },
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title', () => {
-        expect(wrapper.find('title').length).toBe(1);
+      it('should have robots noarchive', () => {
+        const metaValue = metaValues({
+          'page-type': 'article',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='robots']").prop('content')).toEqual('noarchive');
       });
 
-      it('should have meta tags', () => {
-        expect(wrapper.find('meta').length).toBe(9);
+      it('should have og:type', () => {
+        const metaValue = metaValues({
+          'page-type': 'article',
+          title: 'the-sun',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+        expect(wrapper.find("meta[property='og:type']").props().content).toBe('article');
       });
     });
 
-    describe('when need to add a description tag', () => {
-      it('must use the meta value first', () => {
-        const metaValue = (prop: string): string | null => {
-          if (prop === 'page-type') {
-            return 'article';
-          }
-          if (prop === 'title') {
-            return 'the-sun';
-          }
-          if (prop === 'description') {
-            return 'description from metaValue';
-          }
-          return null;
-        };
+    describe('when globalContent is not provided', () => {
+      noGlobalContent('article');
 
-        const useFusionContext = {
-          globalContent: {
-            description: {
-              basic: 'this is a description',
-            },
-          },
-          arcSite: 'the-sun',
-        };
-        const { globalContent } = useFusionContext;
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
-        expect(wrapper.find("meta[name='description']").prop('content')).toEqual(metaValue('description'));
+      it('should have robots noarchive', () => {
+        const metaValue = metaValues({
+          'page-type': 'article',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='robots']").prop('content')).toEqual('noarchive');
       });
 
-      it('must use the global content if metaValue missing', () => {
-        const metaValue = (prop: string): string | null => {
-          if (prop === 'page-type') {
-            return 'article';
-          }
-          if (prop === 'title') {
-            return 'the-sun';
-          }
-          return null;
-        };
+      it('should have og:type', () => {
+        const metaValue = metaValues({
+          'page-type': 'article',
+          title: 'the-sun',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
 
-        const useFusionContext = {
-          globalContent: {
-            description: {
-              basic: 'this is a description',
-            },
-          },
-          arcSite: 'the-sun',
-        };
-        const { globalContent } = useFusionContext;
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
-        expect(wrapper.find("meta[name='description']").prop('content')).toEqual(globalContent.description.basic);
-      });
-
-      it('must not render a description if found no valid values', () => {
-        const metaValue = (prop: string): string | null => {
-          if (prop === 'page-type') {
-            return 'article';
-          }
-          if (prop === 'title') {
-            return 'the-sun';
-          }
-          return null;
-        };
-
-        const useFusionContext = {
-          globalContent: {},
-          arcSite: 'the-sun',
-        };
-        const { globalContent } = useFusionContext;
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
-        expect(wrapper.find("meta[name='description']").length).toBe(0);
-      });
-    });
-
-    describe('when need to add a title tag', () => {
-      it('must use the metaValue first and append the websiteName', () => {
-        const metaValue = (prop: string): string | null => {
-          if (prop === 'page-type') {
-            return 'article';
-          }
-          if (prop === 'title') {
-            return 'title from metaValue';
-          }
-          return null;
-        };
-
-        const useFusionContext = {
-          globalContent: {
-            headlines: {
-              basic: 'this is a headline',
-            },
-          },
-          arcSite: 'the-sun',
-        };
-        const { globalContent } = useFusionContext;
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
-        expect(wrapper.find('title').text()).toEqual(`${metaValue('title')} – ${websiteName}`);
-      });
-
-      it('must use the headlines story if metaValue missing and append the websiteName', () => {
-        const metaValue = (prop: string): string | null => {
-          if (prop === 'page-type') {
-            return 'article';
-          }
-          return null;
-        };
-
-        const useFusionContext = {
-          globalContent: {
-            headlines: {
-              basic: 'this is a headline',
-            },
-          },
-          arcSite: 'the-sun',
-        };
-        const { globalContent } = useFusionContext;
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
-        expect(wrapper.find('title').text()).toEqual(`${globalContent.headlines.basic} – ${websiteName}`);
-      });
-
-      it('must use the websiteName if other values not found ', () => {
-        const metaValue = (prop: string): string | null => {
-          if (prop === 'page-type') {
-            return 'article';
-          }
-          return null;
-        };
-
-        const useFusionContext = {
-          globalContent: {},
-          arcSite: 'the-sun',
-        };
-        const { globalContent } = useFusionContext;
-        const wrapper = shallow(<MetaData
-          metaValue={metaValue}
-          MetaTag={jest.fn()}
-          MetaTags={jest.fn()}
-          globalContent={globalContent}
-          twitterUsername={twitterUsername}
-          websiteName={websiteName}
-          resizerURL={resizerURL}
-        />);
-        expect(wrapper.find('title').text()).toEqual(websiteName);
+        expect(wrapper.find("meta[property='og:type']").props().content).toBe('article');
       });
     });
   });
 
   describe('when a video page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'video';
-        }
-        return null;
-      };
-
-      const useFusionContext = {
-        globalContent: {
-          description: {
-            basic: 'this is a video description',
-          },
-          headlines: {
-            basic: 'this is a video headline',
-          },
-          taxonomy: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            seo_keywords: [
-              'keyword1',
-              'keyword2',
-            ],
-            tags: [
-              { slug: 'tag1' },
-              { slug: 'tag2' },
-            ],
-          },
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          promo_items: {
-            basic: {
-              url: 'awesome-url',
-              // eslint-disable-next-line @typescript-eslint/camelcase
-              alt_text: 'alt text',
-            },
-          },
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a video headline – The Sun');
-      });
-
-      it('should have a video description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a video description');
-      });
-
-      it('should have a video keywords meta tag', () => {
-        expect(wrapper.find("meta[name='keywords']").props().content).toBe('keyword1,keyword2');
-      });
-
-      it('should have a video og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a video headline');
-      });
-
-      it('should have a video og:image meta tag', () => {
-        expect(wrapper.find("meta[property='og:image']").props().content).toBe('https://fake.cdn.com/resizer/l_1yxKdAU0rtnyaww9LofnGAFkw=/1200x630/awesome-url');
-      });
-
-      it('should have a video og:image:alt meta tag', () => {
-        expect(wrapper.find("meta[property='og:image:alt']").props().content).toBe('alt text');
-      });
+      titleTest('video');
+      descriptionTest('video');
+      ogTitleTest('video');
+      ogImageTest('video');
+      ogImageAltTest('video');
+      twitterTitleTest('video');
+      twitterImageTest('video');
+      keywordsTest('video');
 
       it('should not have a robots meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'video',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+
+      it('should not have og:type', () => {
+        const metaValue = metaValues({
+          'page-type': 'video',
+          title: 'the-sun',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+        expect(wrapper.find("meta[property='og:type']").length).toBe(0);
       });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'video';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: null,
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
-      });
-
-      it('should not have a video description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").length).toBe(0);
-      });
-
-      it('should not have a video keywords meta tag', () => {
-        expect(wrapper.find("meta[name='keywords']").length).toBe(0);
-      });
-
-      it('should have a video og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-
-      it('should have a video og:image meta tag', () => {
-        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
-      });
-
-      it('should not have a video og:image:alt meta tag', () => {
-        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
-      });
+      noGlobalContent('video');
 
       it('should not have a robots meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'video',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
-    });
 
-    describe('when custom tags are provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'video';
-        }
-        if (prop === 'description') {
-          return 'this is a custom description';
-        }
-        if (prop === 'title') {
-          return 'this is a custom title';
-        }
-        if (prop === 'og:title') {
-          return 'this is a custom og:title';
-        }
-        if (prop === 'keywords') {
-          return 'custom-keyword1,custom-keyword2';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          description: {
-            basic: 'this is a video description',
-          },
-          headlines: {
-            basic: 'this is a video headline',
-          },
-          taxonomy: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            seo_keywords: [
-              'keyword1',
-              'keyword2',
-            ],
-            tags: [
-              { slug: 'tag1' },
-              { slug: 'tag2' },
-            ],
-          },
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          promo_items: {
-            basic: {
-            },
-          },
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
+      it('should not have og:type', () => {
+        const metaValue = metaValues({
+          'page-type': 'video',
+          title: 'the-sun',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
 
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom title – The Sun');
-      });
-
-      it('should not have a video description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
-      });
-
-      it('should not have a video keywords meta tag', () => {
-        expect(wrapper.find("meta[name='keywords']").props().content).toBe('custom-keyword1,custom-keyword2');
-      });
-
-      it('should have a video og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title');
-      });
-
-      it('should have a video og:image meta tag', () => {
-        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
-      });
-
-      it('should not have a video og:image:alt meta tag', () => {
-        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
-      });
-
-      it('should not have a robots meta tag', () => {
-        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+        expect(wrapper.find("meta[property='og:type']").length).toBe(0);
       });
     });
   });
 
   describe('when a gallery page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'gallery';
-        }
-        return null;
-      };
-
-      const useFusionContext = {
-        globalContent: {
-          description: {
-            basic: 'this is a gallery description',
-          },
-          headlines: {
-            basic: 'this is a gallery headline',
-          },
-          taxonomy: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            seo_keywords: [
-              'keyword1',
-              'keyword2',
-            ],
-            tags: [
-              { slug: 'tag1' },
-              { slug: 'tag2' },
-            ],
-          },
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          promo_items: {
-            basic: {
-              url: 'awesome-url',
-              // eslint-disable-next-line @typescript-eslint/camelcase
-              alt_text: 'alt text',
-            },
-          },
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a gallery headline – The Sun');
-      });
-
-      it('should have a gallery description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a gallery description');
-      });
-
-      it('should have a gallery keywords meta tag', () => {
-        expect(wrapper.find("meta[name='keywords']").props().content).toBe('keyword1,keyword2');
-      });
-
-      it('should have a gallery og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a gallery headline');
-      });
-
-      it('should have a gallery og:image meta tag', () => {
-        expect(wrapper.find("meta[property='og:image']").props().content).toBe('https://fake.cdn.com/resizer/l_1yxKdAU0rtnyaww9LofnGAFkw=/1200x630/awesome-url');
-      });
-
-      it('should have a gallery og:image:alt meta tag', () => {
-        expect(wrapper.find("meta[property='og:image:alt']").props().content).toBe('alt text');
-      });
+      titleTest('gallery');
+      descriptionTest('gallery');
+      ogTitleTest('gallery');
+      ogImageTest('gallery');
+      ogImageAltTest('gallery');
+      twitterTitleTest('gallery');
+      twitterImageTest('gallery');
+      keywordsTest('gallery');
 
       it('should not have a robots meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'gallery',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
+      });
+
+      it('should not have og:type', () => {
+        const metaValue = metaValues({
+          'page-type': 'gallery',
+          title: 'the-sun',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+        expect(wrapper.find("meta[property='og:type']").length).toBe(0);
       });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'gallery';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: null,
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
-      });
-
-      it('should have a gallery description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").length).toBe(0);
-      });
-
-      it('should have a gallery keywords meta tag', () => {
-        expect(wrapper.find("meta[name='keywords']").length).toBe(0);
-      });
-
-      it('should have a gallery og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-
-      it('should have a gallery og:image meta tag', () => {
-        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
-      });
-
-      it('should have a gallery og:image:alt meta tag', () => {
-        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
-      });
+      noGlobalContent('gallery');
 
       it('should not have a robots meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'gallery',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
         expect(wrapper.find("meta[name='robots']").length).toBe(0);
       });
-    });
 
-    describe('when custom tags are provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'gallery';
-        }
-        if (prop === 'description') {
-          return 'this is a custom description';
-        }
-        if (prop === 'title') {
-          return 'this is a custom title';
-        }
-        if (prop === 'og:title') {
-          return 'this is a custom og:title';
-        }
-        if (prop === 'keywords') {
-          return 'custom-keyword1,custom-keyword2';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          description: {
-            basic: 'this is a gallery description',
-          },
-          headlines: {
-            basic: 'this is a gallery headline',
-          },
-          taxonomy: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            seo_keywords: [
-              'keyword1',
-              'keyword2',
-            ],
-            tags: [
-              { slug: 'tag1' },
-              { slug: 'tag2' },
-            ],
-          },
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          promo_items: {
-          },
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
+      it('should not have og:type', () => {
+        const metaValue = metaValues({
+          'page-type': 'gallery',
+          title: 'the-sun',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
 
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom title – The Sun');
-      });
-
-      it('should have a gallery description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
-      });
-
-      it('should have a gallery keywords meta tag', () => {
-        expect(wrapper.find("meta[name='keywords']").props().content).toBe('custom-keyword1,custom-keyword2');
-      });
-
-      it('should have a gallery og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title');
-      });
-
-      it('should have a gallery og:image meta tag', () => {
-        expect(wrapper.find("meta[property='og:image']").length).toBe(0);
-      });
-
-      it('should have a gallery og:image:alt meta tag', () => {
-        expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
-      });
-
-      it('should not have a robots meta tag', () => {
-        expect(wrapper.find("meta[name='robots']").length).toBe(0);
+        expect(wrapper.find("meta[property='og:type']").length).toBe(0);
       });
     });
   });
 
   describe('when an author page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'author';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          authors: [
-            {
-              byline: 'John Doe',
-              bio: 'John Doe is an author',
-            },
-          ],
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('John Doe - The Sun');
+      it('should use metaValue first if exists for description', () => {
+        const metaValue = metaValues({
+          'page-type': 'author',
+          description: 'author meta value bio',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='description']").props().content).toBe(metaValue('description'));
       });
 
-      it('should have an author description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('John Doe is an author');
+      it('should use authors.bio if exists for description', () => {
+        const metaValue = metaValues({
+          'page-type': 'author',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='description']").props().content).toBe(globalContentComplete.authors[0].bio);
       });
 
-      it('should have an author og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('John Doe - The Sun');
+      it('should use metaValue og:title for title', () => {
+        const metaValue = metaValues({
+          'page-type': 'author',
+          'og:title': 'meta value title',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find('title').childAt(0).text(),
+        ).toEqual(
+          `${metaValue('og:title')} - ${websiteName}`,
+        );
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          `${metaValue('og:title')} - ${websiteName}`,
+        );
+      });
+
+      it('should use authors.byline for title if exists', () => {
+        const metaValue = metaValues({
+          'page-type': 'author',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find('title').childAt(0).text(),
+        ).toEqual(
+          `${globalContentComplete.authors[0].byline} - ${websiteName}`,
+        );
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          `${globalContentComplete.authors[0].byline} - ${websiteName}`,
+        );
+      });
+
+      it('should have an author twitter:title meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'author',
+          twitterTitle: 'meta value title',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${metaValue('twitterTitle')} - ${websiteName}`,
+        );
+      });
+
+      it('should use authors.byline if twitterTitle not found', () => {
+        const metaValue = metaValues({
+          'page-type': 'author',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${globalContentComplete.authors[0].byline} - ${websiteName}`,
+        );
       });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'author';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: null,
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
+      const metaValue = metaValues({
+        'page-type': 'author',
+      });
+      const wrapper = wrapperGenerator(metaValue, null);
 
       it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+        expect(wrapper.find('title').childAt(0).text()).toEqual(websiteName);
+        expect(wrapper.find("meta[property='og:title']").prop('content')).toEqual(websiteName);
+        expect(wrapper.find("meta[name='twitter:title']").prop('content')).toEqual(websiteName);
       });
 
-      it('should have an author og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-    });
-
-    describe('when custom tags are provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'author';
-        }
-        if (prop === 'description') {
-          return 'this is a custom description';
-        }
-        if (prop === 'og:title') {
-          return 'this is a custom og:title';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          authors: [
-            {
-              byline: 'John Doe',
-              bio: 'John Doe is an author',
-            },
-          ],
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom og:title - The Sun');
-      });
-
-      it('should have an author description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
-      });
-
-      it('should have an author og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
+      it('should not have description', () => {
+        expect(wrapper.find("meta[name='description']").length).toBe(0);
       });
     });
   });
 
   describe('when a tag page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'tag';
-        }
-        return null;
-      };
-
-      const useFusionContext = {
-        globalContent: {
-          Payload: [
-            {
-              description: 'this is a tag description',
-              name: 'tag name',
-            },
-          ],
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('tag name - The Sun');
+      it('should use metaValue first if exists for description', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+          description: 'tag meta valu',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='description']").prop('content')).toBe(metaValue('description'));
       });
 
-      it('should have a tag description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a tag description');
+      it('should use Payload.description if exists for description', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='description']").prop('content')).toBe(globalContentComplete.Payload[0].description);
       });
 
-      it('should have a tag og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('tag name - The Sun');
+      it('should use metaValue og:title for title', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+          'og:title': 'meta value title',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find('title').childAt(0).text(),
+        ).toEqual(
+          `${metaValue('og:title')} - ${websiteName}`,
+        );
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          `${metaValue('og:title')} - ${websiteName}`,
+        );
+      });
+
+      it('should have an author twitter:title meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+          twitterTitle: 'meta value title',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${metaValue('twitterTitle')} - ${websiteName}`,
+        );
+      });
+
+      it('should use Payload.name for title if exists', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find('title').childAt(0).text(),
+        ).toEqual(
+          `${globalContentComplete.Payload[0].name} - ${websiteName}`,
+        );
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          `${globalContentComplete.Payload[0].name} - ${websiteName}`,
+        );
+      });
+
+      it('should have an author twitter:title meta tag', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+          twitterTitle: 'meta value title',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${metaValue('twitterTitle')} - ${websiteName}`,
+        );
+      });
+
+      it('should use authors.byline if twitterTitle not found', () => {
+        const metaValue = metaValues({
+          'page-type': 'tag',
+        });
+
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${globalContentComplete.Payload[0].name} - ${websiteName}`,
+        );
       });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'tag';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: null,
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
+      const metaValue = metaValues({
+        'page-type': 'tag',
+      });
+      const wrapper = wrapperGenerator(metaValue, null);
 
       it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+        expect(wrapper.find('title').childAt(0).text()).toEqual(websiteName);
+        expect(wrapper.find("meta[property='og:title']").prop('content')).toEqual(websiteName);
+        expect(wrapper.find("meta[name='twitter:title']").prop('content')).toEqual(websiteName);
       });
 
-      it('should not have a tag description meta tag', () => {
+      it('should not have description', () => {
         expect(wrapper.find("meta[name='description']").length).toBe(0);
-      });
-
-      it('should have a tag og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-    });
-
-    describe('when custom tags are provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'tag';
-        }
-        if (prop === 'description') {
-          return 'this is a custom description';
-        }
-        if (prop === 'og:title') {
-          return 'this is a custom og:title';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          Payload: [
-            {
-              description: 'this is a tag description',
-              name: 'tag name',
-            },
-          ],
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom og:title - The Sun');
-      });
-
-      it('should have a tag description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
-      });
-
-      it('should have a tag og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
       });
     });
   });
 
   describe('when a section page type is provided', () => {
     describe('when global content is provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'section';
-        }
-        return null;
-      };
-
-      const useFusionContext = {
-        globalContent: {
-          name: 'Entertainment',
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('Entertainment - The Sun');
+      it('should use metaValue first if exists for description', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+          description: 'section meta valu',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='description']").prop('content')).toBe(metaValue('description'));
       });
 
-      it('should not have a section description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").length).toBe(0);
+      it('should use metadata_description if exists for description', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(wrapper.find("meta[name='description']").prop('content')).toBe(globalContentComplete.metadata.metadata_description);
       });
 
-      it('should have a section og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
+      describe('title handling', () => {
+        it('should use metaValue title for title', () => {
+          const metaValue = metaValues({
+            'page-type': 'section',
+            title: 'meta value title',
+          });
+
+          const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+          expect(
+            wrapper.find('title').childAt(0).text(),
+          ).toEqual(
+            metaValue('title'),
+          );
+        });
+
+        it('should use metadata_title if title not found', () => {
+          const metaValue = metaValues({
+            'page-type': 'section',
+          });
+
+          const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+          expect(
+            wrapper.find('title').childAt(0).text(),
+          ).toBe(
+            globalContentComplete.metadata.metadata_title,
+          );
+        });
+
+        it('should use gc.name if metadata_title and title are missing', () => {
+          const metaValue = metaValues({
+            'page-type': 'section',
+          });
+          const content = {
+            ...globalContentComplete,
+            metadata: {},
+          };
+
+          const wrapper = wrapperGenerator(metaValue, content);
+          expect(
+            wrapper.find('title').childAt(0).text(),
+          ).toEqual(
+            `${content.name} - ${websiteName}`,
+          );
+        });
+
+        it('should use og:title if metadata_title, title and gc.name are missing', () => {
+          const metaValue = metaValues({
+            'page-type': 'section',
+            'og:title': 'meta value og:title',
+          });
+          const content = {
+            ...globalContentComplete,
+            name: null,
+            metadata: {},
+          };
+
+          const wrapper = wrapperGenerator(metaValue, content);
+          expect(
+            wrapper.find('title').childAt(0).text(),
+          ).toEqual(
+            `${metaValue('og:title')} - ${websiteName}`,
+          );
+        });
+      });
+
+      it('should use og:title', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+          'og:title': 'meta value og:title',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          `${metaValue('og:title')} - ${websiteName}`,
+        );
+      });
+
+      it('should use gc.name if og:title missing', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          `${globalContentComplete.name} - ${websiteName}`,
+        );
+      });
+
+      it('should use websiteName if gc.name and og:title are missing', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+        });
+        const content = {
+          ...globalContentComplete,
+          name: null,
+        };
+        const wrapper = wrapperGenerator(metaValue, content);
+        expect(
+          wrapper.find("meta[property='og:title']").prop('content'),
+        ).toBe(
+          websiteName,
+        );
+      });
+
+      it('should use twitterTitle', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+          twitterTitle: 'meta value twitterTitle',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${metaValue('twitterTitle')} - ${websiteName}`,
+        );
+      });
+
+      it('should use gc.name if twitterTitle is missing', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+        });
+        const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          `${globalContentComplete.name} - ${websiteName}`,
+        );
+      });
+
+      it('should use websiteName if twitterTitle is missing', () => {
+        const metaValue = metaValues({
+          'page-type': 'section',
+        });
+        const content = {
+          ...globalContentComplete,
+          name: null,
+        };
+        const wrapper = wrapperGenerator(metaValue, content);
+        expect(
+          wrapper.find("meta[name='twitter:title']").prop('content'),
+        ).toBe(
+          websiteName,
+        );
       });
     });
 
     describe('when global content is not provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'section';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: null,
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
+      const metaValue = metaValues({
+        'page-type': 'section',
+      });
+      const wrapper = wrapperGenerator(metaValue, null);
 
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+      it('should use websiteName as title', () => {
+        expect(wrapper.find('title').childAt(0).text()).toEqual(websiteName);
       });
 
       it('should not have a section description meta tag', () => {
         expect(wrapper.find("meta[name='description']").length).toBe(0);
       });
 
-      it('should have a section og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
-      });
-    });
-
-    describe('when custom tags are provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'section';
-        }
-        if (prop === 'description') {
-          return 'this is a custom description';
-        }
-        if (prop === 'og:title') {
-          return 'this is a custom og:title';
-        }
-        if (prop === 'title') {
-          return 'this is a custom title';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          metadata: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            metadata_title: 'This is a metadata title',
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            metadata_description: 'This is a metadata description',
-          },
-          name: 'Entertainment',
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('this is a custom title');
+      it('should use websiteName as og:title meta tag', () => {
+        expect(wrapper.find("meta[property='og:title']").prop('content')).toBe(websiteName);
       });
 
-      it('should have a tag description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('this is a custom description');
-      });
-
-      it('should have a tag og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('this is a custom og:title - The Sun');
-      });
-    });
-
-    describe('when metadata fields in global content are provided', () => {
-      const metaValue = (prop: string): string | null => {
-        if (prop === 'page-type') {
-          return 'section';
-        }
-        return null;
-      };
-      const useFusionContext = {
-        globalContent: {
-          metadata: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            metadata_title: 'This is a metadata title',
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            metadata_description: 'This is a metadata description',
-          },
-          name: 'Entertainment',
-        },
-        arcSite: 'the-sun',
-      };
-      const { globalContent } = useFusionContext;
-
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
-      it('should have a title tag', () => {
-        expect(wrapper.find('title').childAt(0).text()).toEqual('This is a metadata title');
-      });
-
-      it('should have a tag description meta tag', () => {
-        expect(wrapper.find("meta[name='description']").props().content).toBe('This is a metadata description');
-      });
-
-      it('should have a tag og:title meta tag', () => {
-        expect(wrapper.find("meta[property='og:title']").props().content).toBe('Entertainment - The Sun');
+      it('should use websiteName as twitter:title meta tag', () => {
+        expect(wrapper.find("meta[name='twitter:title']").prop('content')).toBe(websiteName);
       });
     });
   });
 
-  describe('twitter meta', () => {
-    const metaValue = (prop: string): string | null => {
-      if (prop === 'page-type') {
-        return 'article';
-      }
-      if (prop === 'title') {
-        return 'the-sun';
-      }
-      return null;
-    };
+  describe('when a search page type is provided', () => {
+    it('should use websiteName as title', () => {
+      const metaValue = metaValues({
+        'page-type': 'search',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('title').childAt(0).text()).toEqual(`Search - ${websiteName}`);
+    });
 
-    const useFusionContext = {
-      globalContent: {
-        description: {
-          basic: 'this is a description',
-        },
-        headlines: {
-          basic: 'this is a headline',
-        },
-        taxonomy: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          seo_keywords: [
-            'keyword1',
-            'keyword2',
-          ],
-          tags: [
-            { slug: 'tag1' },
-            { slug: 'tag2' },
-          ],
-        },
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        promo_items: {
-          basic: {
-            url: 'awesome-url',
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            alt_text: 'alt text',
-          },
-        },
-      },
-      arcSite: 'the-sun',
-    };
-    const { globalContent } = useFusionContext;
+    it('should use websiteName as og:title', () => {
+      const metaValue = metaValues({
+        'page-type': 'search',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[property='og:title']").prop('content'),
+      ).toBe(`Search - ${websiteName}`);
+    });
+
+    it('should use websiteName as twitter:title', () => {
+      const metaValue = metaValues({
+        'page-type': 'search',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(
+        wrapper.find("meta[name='twitter:title']").prop('content'),
+      ).toBe(`Search - ${websiteName}`);
+    });
+  });
+
+  describe('twitter meta', () => {
+    const metaValue = metaValues({
+      'page-type': 'article',
+      title: 'the-sun',
+    });
 
     it('should have twitter tags', () => {
-      const wrapper = shallow(<MetaData
-        metaValue={metaValue}
-        MetaTag={jest.fn()}
-        MetaTags={jest.fn()}
-        globalContent={globalContent}
-        twitterUsername={twitterUsername}
-        websiteName={websiteName}
-        resizerURL={resizerURL}
-      />);
-
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
       expectTwitterMeta(wrapper);
     });
 
@@ -1206,7 +1141,7 @@ describe('the meta data ', () => {
         metaValue={metaValue}
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
-        globalContent={globalContent}
+        globalContent={globalContentComplete}
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
@@ -1219,13 +1154,94 @@ describe('the meta data ', () => {
         metaValue={metaValue}
         MetaTag={jest.fn()}
         MetaTags={jest.fn()}
-        globalContent={globalContent}
+        globalContent={globalContentComplete}
         twitterUsername=""
         websiteName={websiteName}
         resizerURL={resizerURL}
       />);
 
       expectTwitterMetaMissing(wrapper);
+    });
+  });
+
+  describe('facebook article meta', () => {
+    it('articles pages must have og:type = article', () => {
+      const metaValue = metaValues({
+        'page-type': 'article',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+      expect(wrapper.find("meta[property='og:type']").props().content).toBe('article');
+    });
+
+    it('no articles pages must not have og:type = article', () => {
+      const metaValue = metaValues({
+        'page-type': 'video',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+      expect(wrapper.find("meta[property='og:type']").length).toBe(0);
+    });
+  });
+
+  describe('all pages tags', () => {
+    it('all pages must have this social tags', () => {
+      const metaValue = metaValues({
+        'page-type': 'all-pages',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+      expect(wrapper.find("meta[property='og:site_name']").prop('content')).toEqual(websiteName);
+      expect(wrapper.find("meta[name='twitter:site']").prop('content')).toEqual(`@${twitterUsername}`);
+      expect(wrapper.find("meta[name='twitter:card']").prop('content')).toEqual('summary_large_image');
+      expect(wrapper.find("meta[property='fb:admins']").prop('content')).toEqual(facebookAdmins);
+    });
+
+    it('must have the og:url if can build the page url', () => {
+      const metaValue = metaValues({
+        'page-type': 'all-pages',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      const url = `${websiteDomain}${globalContentComplete.websites[arcSite].website_url}`;
+
+      expect(wrapper.find("meta[property='og:url']").prop('content')).toEqual(url);
+    });
+  });
+
+  describe('all pages tags without globalContent', () => {
+    it('all pages must have this social tags', () => {
+      const metaValue = metaValues({
+        'page-type': 'all-pages',
+      });
+      const wrapper = wrapperGenerator(metaValue, null);
+
+      expect(wrapper.find("meta[property='og:site_name']").prop('content')).toEqual(websiteName);
+      expect(wrapper.find("meta[name='twitter:site']").prop('content')).toEqual(`@${twitterUsername}`);
+      expect(wrapper.find("meta[name='twitter:card']").prop('content')).toEqual('summary_large_image');
+      expect(wrapper.find("meta[property='fb:admins']").prop('content')).toEqual(facebookAdmins);
+    });
+
+    it('must not have og:url if not has globalContent', () => {
+      const metaValue = metaValues({
+        'page-type': 'all-pages',
+      });
+      const wrapper = wrapperGenerator(metaValue, null);
+
+      expect(wrapper.find("meta[property='og:url']").length).toBe(0);
+    });
+
+    it('must not have og:url if can not build the url', () => {
+      const metaValue = metaValues({
+        'page-type': 'all-pages',
+      });
+      const localContent = {
+        ...globalContentComplete,
+        websites: {},
+      };
+      const wrapper = wrapperGenerator(metaValue, localContent);
+      expect(wrapper.find("meta[property='og:url']").length).toBe(0);
     });
   });
 });

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -1244,4 +1244,10 @@ describe('the meta data ', () => {
       expect(wrapper.find("meta[property='og:url']").length).toBe(0);
     });
   });
+
+  describe('when page type is not provided', () => {
+    describe('must reder default meta tags', () => {
+      noGlobalContent('');
+    });
+  });
 });

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -23,7 +23,7 @@ interface MetaValuesReturnInterface {
 }
 
 interface GlobalContentBag {
-  [x: string]: object;
+  [x: string]: unknown;
 }
 
 const websiteName = 'The Sun';
@@ -485,11 +485,10 @@ const noGlobalContent = (pageType: string): void => {
   const metaValue = metaValues({
     'page-type': pageType,
   });
-  const globalContent = null;
-  const wrapper = wrapperGenerator(metaValue, globalContent);
+  const wrapper = wrapperGenerator(metaValue, null);
 
   it('should have a title tag', () => {
-    expect(wrapper.find('title').childAt(0).text()).toEqual('The Sun');
+    expect(wrapper.find('title').childAt(0).text()).toEqual(websiteName);
   });
 
   it('should not have a description meta tag', () => {
@@ -509,18 +508,18 @@ const noGlobalContent = (pageType: string): void => {
   });
 
   it('should have a og:title meta tag', () => {
-    expect(wrapper.find("meta[property='og:title']").props().content).toBe('The Sun');
+    expect(wrapper.find("meta[property='og:title']").prop('content')).toBe(websiteName);
   });
 
   it('should have a twitter:title meta tag', () => {
-    expect(wrapper.find("meta[name='twitter:title']").props().content).toBe('The Sun');
+    expect(wrapper.find("meta[name='twitter:title']").prop('content')).toBe(websiteName);
   });
 
-  it('should have a og:image meta tag', () => {
+  it('should not have an og:image meta tag', () => {
     expect(wrapper.find("meta[property='og:image']").length).toBe(0);
   });
 
-  it('should not have a og:image:alt meta tag', () => {
+  it('should not have an og:image:alt meta tag', () => {
     expect(wrapper.find("meta[property='og:image:alt']").length).toBe(0);
   });
 };

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -9,7 +9,7 @@ interface CustomMetaData {
 }
 
 interface GlobalContentBag {
-  [x: string]: object;
+  [x: string]: unknown;
 }
 
 const getCustomMetaData = (metaHTMLString: string): Array<CustomMetaData> => {

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -310,6 +310,13 @@ const MetaData: React.FC<Props> = ({
         <meta name="twitter:title" content={metaData.twitterTitle} />
       </>
     );
+  } else {
+    sectionMetaDataTags = (
+      <>
+        <meta property="og:title" content={metaData.title} />
+        <meta name="twitter:title" content={metaData.title} />
+      </>
+    );
   }
   // Twitter meta tags go on all pages
   const twitterTags = (

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -8,6 +8,10 @@ interface CustomMetaData {
   metaValue: string;
 }
 
+interface GlobalContentBag {
+  [x: string]: object;
+}
+
 const getCustomMetaData = (metaHTMLString: string): Array<CustomMetaData> => {
   let customMetaData = null;
   if (typeof window === 'undefined') {
@@ -35,6 +39,14 @@ const generateCustomMetaTags = (metaData, MetaTag, MetaTags): ReactElement => {
       ))}
     </>
   );
+};
+
+const generateUrl = (arcSite: string, websiteDomain: string, gc: GlobalContentBag): string => {
+  const siteData = gc && gc.websites && gc.websites[arcSite];
+  if (!siteData) {
+    return null;
+  }
+  return `${websiteDomain}${siteData.website_url}`;
 };
 
 interface Props {
@@ -69,14 +81,26 @@ interface Props {
     };
   } | null;
   websiteName?: string | null;
+  websiteDomain?: string | null;
   twitterUsername?: string | null;
   resizerURL?: string | null;
+  arcSite?: string | null;
+  facebookAdmins?: string | null;
 }
 
 const MetaData: React.FC<Props> = ({
-  MetaTag, MetaTags, metaValue, globalContent: gc, websiteName, twitterUsername, resizerURL,
+  MetaTag,
+  MetaTags,
+  metaValue,
+  globalContent: gc,
+  websiteName,
+  websiteDomain,
+  twitterUsername,
+  resizerURL,
+  arcSite,
+  facebookAdmins,
 }) => {
-  const pageType = metaValue('page-type') || '';
+  const pageType = metaValue('page-type');
 
   let storyMetaDataTags = null;
   let tagMetaDataTags = null;
@@ -91,12 +115,15 @@ const MetaData: React.FC<Props> = ({
     keywords: null,
     ogImage: null,
     ogImageAlt: null,
+    url: generateUrl(arcSite, websiteDomain, gc),
     'page-type': pageType,
     title: websiteName,
     ogTitle: websiteName,
     ogSiteName: websiteName,
     twitterUsername: twitterUsername ? `@${twitterUsername}` : null,
     twitterCard: 'summary_large_image',
+    twitterTitle: websiteName,
+    twitterImage: null,
   };
 
   if (pageType === 'article' || pageType === 'video' || pageType === 'gallery') {
@@ -115,6 +142,8 @@ const MetaData: React.FC<Props> = ({
       metaData.ogTitle = metaValue('og:title') || headline || websiteName;
       metaData.ogImage = getImgURL(metaValue, 'og:image', gc, resizerURL);
       metaData.ogImageAlt = getImgAlt(metaValue, 'og:image:alt', gc);
+      metaData.twitterTitle = metaValue('twitterTitle') || headline || websiteName;
+      metaData.twitterImage = getImgURL(metaValue, 'twitterImage', gc, resizerURL);
 
       // Keywords could be comma delimited string or array of string or an array of objects
       if (metaValue('keywords')) {
@@ -129,6 +158,7 @@ const MetaData: React.FC<Props> = ({
           gc.taxonomy.tags.forEach((item) => {
             if (item.slug) metaData.keywords.push(item.slug);
           });
+          metaData.keywords = metaData.keywords.join(',');
         }
       } else {
         metaData.keywords = null;
@@ -137,8 +167,13 @@ const MetaData: React.FC<Props> = ({
       storyMetaDataTags = (
         <>
           {
-            metaData.description
-            && <meta name="description" content={metaData.description} />
+            metaData.description && (
+              <>
+                <meta name="description" content={metaData.description} />
+                <meta name="twitter:description" content={metaData.description} />
+                <meta property="og:description" content={metaData.description} />
+              </>
+            )
           }
           {
             metaData.keywords
@@ -146,10 +181,15 @@ const MetaData: React.FC<Props> = ({
           }
 
           <meta property="og:title" content={metaData.ogTitle} />
+          <meta name="twitter:title" content={metaData.twitterTitle} />
 
           {
             metaData.ogImage
             && <meta property="og:image" content={metaData.ogImage} />
+          }
+          {
+            metaData.twitterImage
+            && <meta name="twitter:image" content={metaData.twitterImage} />
           }
           {
             metaData.ogImageAlt
@@ -157,7 +197,10 @@ const MetaData: React.FC<Props> = ({
           }
           {
             pageType === 'article' && (
-              <meta name="robots" content="noarchive" />
+              <>
+                <meta property="og:type" content="article" />
+                <meta name="robots" content="noarchive" />
+              </>
             )
           }
         </>
@@ -167,12 +210,20 @@ const MetaData: React.FC<Props> = ({
     const author = (gc && gc.authors && gc.authors.length) ? gc.authors[0] : {};
     metaData.description = metaValue('description') || author.bio || null;
     metaData.ogTitle = metaValue('og:title') || author.byline || '';
+    metaData.twitterTitle = metaValue('twitterTitle') || author.byline || '';
+
     if (metaData.ogTitle === '') {
       metaData.title = websiteName;
       metaData.ogTitle = websiteName;
     } else {
       metaData.title = `${metaData.ogTitle} - ${websiteName}`;
       metaData.ogTitle = `${metaData.ogTitle} - ${websiteName}`;
+    }
+
+    if (metaData.twitterTitle === '') {
+      metaData.twitterTitle = websiteName;
+    } else {
+      metaData.twitterTitle = `${metaData.twitterTitle} - ${websiteName}`;
     }
 
     authorMetaDataTags = (
@@ -182,6 +233,7 @@ const MetaData: React.FC<Props> = ({
           && <meta name="description" content={metaData.description} />
         }
         <meta property="og:title" content={metaData.ogTitle} />
+        <meta name="twitter:title" content={metaData.twitterTitle} />
       </>
     );
   } else if (pageType === 'search') {
@@ -191,18 +243,27 @@ const MetaData: React.FC<Props> = ({
     searchMetaDataTags = (
       <>
         <meta property="og:title" content={metaData.ogTitle} />
+        <meta name="twitter:title" content={metaData.ogTitle} />
       </>
     );
   } else if (pageType === 'tag') {
     const payload = (gc && gc.Payload && gc.Payload.length) ? gc.Payload[0] : {};
     metaData.description = metaValue('description') || payload.description || null;
     metaData.ogTitle = metaValue('og:title') || payload.name || '';
+    metaData.twitterTitle = metaValue('twitterTitle') || payload.name || '';
+
     if (metaData.ogTitle === '') {
       metaData.title = websiteName;
       metaData.ogTitle = websiteName;
     } else {
       metaData.title = `${metaData.ogTitle} - ${websiteName}`;
       metaData.ogTitle = `${metaData.ogTitle} - ${websiteName}`;
+    }
+
+    if (metaData.twitterTitle === '') {
+      metaData.twitterTitle = websiteName;
+    } else {
+      metaData.twitterTitle = `${metaData.twitterTitle} - ${websiteName}`;
     }
 
     tagMetaDataTags = (
@@ -212,6 +273,7 @@ const MetaData: React.FC<Props> = ({
           && <meta name="description" content={metaData.description} />
         }
         <meta property="og:title" content={metaData.ogTitle} />
+        <meta name="twitter:title" content={metaData.twitterTitle} />
       </>
     );
   } else if (pageType === 'section') {
@@ -220,6 +282,8 @@ const MetaData: React.FC<Props> = ({
     metaData.description = metaValue('description') || gcMetadata.metadata_description || null;
     metaData.ogTitle = metaValue('og:title') || payload.name || '';
     metaData.title = metaValue('title') || gcMetadata.metadata_title || payload.name || '';
+    metaData.twitterTitle = metaValue('twitterTitle') || payload.name || '';
+
     if (metaData.ogTitle === '') {
       metaData.ogTitle = websiteName;
     } else {
@@ -230,6 +294,11 @@ const MetaData: React.FC<Props> = ({
     } else if (metaData.title === payload.name) {
       metaData.title = `${metaData.title} - ${websiteName}`;
     }
+    if (metaData.twitterTitle === '') {
+      metaData.twitterTitle = websiteName;
+    } else {
+      metaData.twitterTitle = `${metaData.twitterTitle} - ${websiteName}`;
+    }
 
     sectionMetaDataTags = (
       <>
@@ -238,6 +307,7 @@ const MetaData: React.FC<Props> = ({
           && <meta name="description" content={metaData.description} />
         }
         <meta property="og:title" content={metaData.ogTitle} />
+        <meta name="twitter:title" content={metaData.twitterTitle} />
       </>
     );
   }
@@ -249,12 +319,20 @@ const MetaData: React.FC<Props> = ({
         && <meta property="og:site_name" content={metaData.ogSiteName} />
       }
       {
+        metaData.url
+        && <meta property="og:url" content={metaData.url} />
+      }
+      {
         metaData.twitterUsername
-        && <meta property="twitter:site" content={metaData.twitterUsername} />
+        && <meta name="twitter:site" content={metaData.twitterUsername} />
       }
       {
         metaData.twitterCard
-        && <meta property="twitter:card" content={metaData.twitterCard} />
+        && <meta name="twitter:card" content={metaData.twitterCard} />
+      }
+      {
+        facebookAdmins
+        && <meta property="fb:admins" content={facebookAdmins} />
       }
     </>
   );


### PR DESCRIPTION
## Description
update social tags support on MetaData component

## Jira Ticket
- [PEN-1303](https://arcpublishing.atlassian.net/browse/PEN-1303)

## Acceptance Criteria
The following metadata tags are added to all pages. (Note that these should all be able to re-use existing values that we use in other metadata tags): 
```
  <meta property="twitter:title" content={metaData.ogTitle} /> 
  <meta property="twitter:image" content={metaData.ogImage} /> 
  <meta property="twitter:description" content={metaData.description} /> 
  <meta property="og:description" content={metaData.description} /> 
```

 The following metadata tags are added only if a page is page-type: article 
```
  <meta property="og:type" content="article" /> 
```
(Note that content is hard-coded to “article” here) 
* Create a new (optional) Theme Setting called facebookAdmins. If this value is present for a given Theme website, it should be added to the page as the content for meta property="fb:admins" 
* The content of meta property="og:url" should be set to the URL being rendered in the browser
* Tests and documentation should be updated to cover this functionality 


## Test Steps
- tests written

## Effect Of Changes
### Before
<img width="900" alt="Screen Shot 2020-09-30 at 10 55 22" src="https://user-images.githubusercontent.com/9757/94696212-2da24700-030d-11eb-94f6-2c94b5d7e63f.png">

### After
<img width="1411" alt="Screen Shot 2020-09-30 at 10 53 45" src="https://user-images.githubusercontent.com/9757/94696231-3266fb00-030d-11eb-82b5-88efdcef73bd.png">

## Dependencies or Side Effects
- updated `News-Theme-Block` with `facebookAdmins` property https://github.com/WPMedia/Fusion-News-Theme/pull/118
- updated `fusion-news-theme-block` `default-output-block` with new MetaData properties https://github.com/WPMedia/fusion-news-theme-blocks/pull/465
- those PR no need to merge before this one, but are required for testing

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
