### PR TITLE
fix merge from PEN-1303 to canary

### DIFF
--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -311,6 +311,8 @@ const MetaData: React.FC<Props> = ({
         <meta name="twitter:title" content={metaData.twitterTitle} />
       </>
     );
+  } else if (pageType === 'homepage') {
+    homepageMetaDataTags = <meta property="og:title" content={metaData.ogTitle} />;
   } else {
     sectionMetaDataTags = (
       <>
@@ -318,8 +320,6 @@ const MetaData: React.FC<Props> = ({
         <meta name="twitter:title" content={metaData.title} />
       </>
     );
-  } else if (pageType === 'homepage') {
-    homepageMetaDataTags = <meta property="og:title" content={metaData.ogTitle} />;
   }
   // Twitter meta tags go on all pages
   const twitterTags = (


### PR DESCRIPTION
## Description
When merged https://github.com/WPMedia/engine-theme-sdk/pull/98 into `canary`, the merge resolution generated a syntax error on the resulting code

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
