### PR TITLE
Allowing for compressed strings that may use a format other than JPG

### DIFF
--- a/src/components/Image/thumbor-image-url.test.ts
+++ b/src/components/Image/thumbor-image-url.test.ts
@@ -3,6 +3,7 @@ import buildThumborURL from './thumbor-image-url';
 describe('thumbor image url function', () => {
   const targetImageKey = '/r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:format(jpg):quality(70)/';
   const targetImageKeyCompressed = 'r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:cm=t/';
+  const targetImageKeyPngCompressed = 'r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:format(png):cm=t/';
   const targetImageKeyNoFilters = '/r4YXPy4Eh2thx80bDTxRZM9Syhw=/';
   const imageSource = 'www.hey.com/ffdfdf';
   const resizerURL = 'www.hey.resizer.com';
@@ -17,6 +18,9 @@ describe('thumbor image url function', () => {
   });
   it('returns a well-formed url image if filters have been assumed defaulted (with the cm=t param) to a format of jpg and quality of 70', () => {
     expect(buildThumborURL(targetImageKeyCompressed, '100x100', imageSource, resizerURL)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100/filters:format(jpg):quality(70)/www.hey.com/ffdfdf');
+  });
+  it('returns a well-formed url image if filter quality have been assumed defaulted at 70 (with the cm=t param) but with a format of png', () => {
+    expect(buildThumborURL(targetImageKeyPngCompressed, '100x100', imageSource, resizerURL)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100/filters:format(png):quality(70)/www.hey.com/ffdfdf');
   });
   it('retuns well-formed url with no filters', () => {
     expect(buildThumborURL(targetImageKeyNoFilters, '100x100', imageSource, resizerURL)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100//www.hey.com/ffdfdf');

--- a/src/components/Image/thumbor-image-url.ts
+++ b/src/components/Image/thumbor-image-url.ts
@@ -19,7 +19,11 @@ const buildThumborURL = (
    */
   let uncompressedTarget = targetImageKeyWithFilter;
   if (uncompressedTarget.indexOf(':cm=t') !== -1) {
-    uncompressedTarget = uncompressedTarget.replace(':cm=t', ':format(jpg):quality(70)');
+    if (uncompressedTarget.indexOf(':format') === -1) {
+      uncompressedTarget = uncompressedTarget.replace(':cm=t', ':format(jpg):quality(70)');
+    } else {
+      uncompressedTarget = uncompressedTarget.replace(':cm=t', ':quality(70)');
+    }
     uncompressedTarget = `/${uncompressedTarget}`;
   }
 


### PR DESCRIPTION
## Description
_Information about what you changed for this PR_

## Jira Ticket
- PEN-1313

## Acceptance Criteria
Ensure that a compressed image URI can also handle other image formats

## Test Steps
src/components/Image/thumbor-image-url.test.ts

## Notes
This PR addresses a fix for a previous commit where compressed image URI's were not accounting for the possibility of a format other than JPG.
