### PR TITLE
PEN-1298: Add Canary release Github action (Step 1)

### DIFF
--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -54,6 +54,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: git add . && git commit -m "New version" && git push origin test-canary-build
+      - name: Push tags
+        uses: actions/checkout@v2
+        with:
+          node-version: '12'
+          registry-url: 'https://npm.pkg.github.com'
+        run: git add . && git commit -m "New version" && git push origin
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
       
       - run: npm version prerelease --preid=canary
         env:

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -53,3 +53,7 @@ jobs:
       - run: npm publish --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: git add . && git commit -m "New version" && git push
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -7,9 +7,7 @@ on:
     branches:
       - test-canary-build
 
-# Publishes Canary builds with the dist tag of "canary" and
-# with a version of 0.0.0 with a short git SHA appended to
-# the end.
+# Publishes Canary builds with the dist tag of "canary"
 jobs:
   # This workflow contains a single job called "publish"
   publish:
@@ -41,14 +39,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
 
+      # Git init
       - run: git config --global user.email "beltran.caliz@ewashpost.com" && git config --global user.name "beltrancaliz"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
       
+      # Prerelease (tests and lint)
       - run: npm version prerelease --preid=canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
+      # Publish
       - run: npm publish --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -1,11 +1,11 @@
 name: Canary build
 
 # Controls when the action will run. Triggers the workflow on push
-# events but only for the test-canary-build branch
+# events but only for the canary branch
 on:
   push:
     branches:
-      - test-canary-build
+      - canary
 
 # Publishes Canary builds with the dist tag of "canary"
 jobs:
@@ -53,11 +53,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       # Publish
-      - run: npm publish --tag test-canary-build
+      - run: npm publish --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Push tag
-      - run: git push origin test-canary-build
+      - run: git push origin canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -54,6 +54,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: git add . && git commit -m "New version" && git push
+      - run: git add . && git commit -m "New version" && git push origin test-canary-build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -40,6 +40,10 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
+
+      - run: git config --global user.email "beltran.caliz@ewashpost.com" && git config --global user.name "beltrancaliz"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
       
       - run: npm version prerelease --preid=canary
         env:

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -1,7 +1,7 @@
 name: Canary build
 
 # Controls when the action will run. Triggers the workflow on push
-# events but only for the test-canary-branch branch
+# events but only for the test-canary-build branch
 on:
   push:
     branches:
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
+      # Caches NPM files
       - name: Cache NPM files
         uses: actions/cache@v2
         with:
@@ -29,18 +30,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      # Sets up Node v12
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '12'
           registry-url: 'https://npm.pkg.github.com'
 
+      # NPM ci init
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
 
-      # Git init
-      - run: git config --global user.email "beltran.caliz@ewashpost.com" && git config --global user.name "beltrancaliz"
+      # Git config
+      - run: git config --global user.email "beltran.caliz@washpost.com" && git config --global user.name "beltrancaliz"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
       
@@ -50,10 +53,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       # Publish
-      - run: npm publish --tag canary
+      - run: npm publish --tag test-canary-build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Push tag
       - run: git push origin test-canary-build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -54,13 +54,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push tags
-        uses: actions/checkout@v2
-        with:
-          node-version: '12'
-          registry-url: 'https://npm.pkg.github.com'
-        run: git add . && git commit -m "New version" && git push origin
+      - run: git add package.json
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      
+      - run: git commit -m "New version"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: git push origin test-canary-build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -54,14 +54,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: git add package.json
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: git commit -m "New version"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - run: git push origin test-canary-build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -1,0 +1,50 @@
+name: Canary build
+
+# Controls when the action will run. Triggers the workflow on push
+# events but only for the test-canary-branch branch
+on:
+  push:
+    branches:
+      - test-canary-build
+
+# Publishes Canary builds with the dist tag of "canary" and
+# with a version of 0.0.0 with a short git SHA appended to
+# the end.
+jobs:
+  # This workflow contains a single job called "publish"
+  publish:
+    name: Canary build publish
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Cache NPM files
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+      
+      - run: npm version prerelease --preid=canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - run: npm publish --tag canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.6",
+  "version": "2.4.0-canary.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.11",
+  "version": "2.4.0-canary.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.5",
+  "version": "2.4.0-canary.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.11",
+  "version": "2.4.0-canary.12",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.7",
+  "version": "2.4.0-canary.8",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.9",
+  "version": "2.4.0-canary.10",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.10",
+  "version": "2.4.0-canary.11",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.5",
+  "version": "2.4.0-canary.6",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.6",
+  "version": "2.4.0-canary.7",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.4.0-canary.8",
+  "version": "2.4.0-canary.9",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## Description
Added a Github action to automate Engine Theme SDK canary releases. This runs on every push to the canary branch.
Relevant documentation will be updated on later steps of this ticket

## Jira Ticket
- [PEN-1298](https://arcpublishing.atlassian.net/browse/PEN-1298)

## Acceptance Criteria
On merge into stable branch name, should publish to stable tag. Same with canary and beta branches and tags 

## Test Steps
Push or make a PR against the canary branch and see the action being triggered and successfully publishing a new Engine Theme SDK version (run `npm view @wpmedia/engine-theme-sdk` to verify)

## Effect Of Changes
### Before
Engine Theme SDK canary releases have to be done by manually running publishing commands 

### After
Engine Theme SDK canary releases are now done automatically through a Github action. This reduces chances of errors like a forgotten local tag that wasn't pushed.

![image](https://user-images.githubusercontent.com/21249916/97322057-b6aa9080-186f-11eb-8202-f510d39e3958.png)


## Dependencies or Side Effects
None

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
