### PR TITLE
PEN-1298: Add Stable release Github action (Step 3)

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -1,0 +1,62 @@
+name: Stable build
+
+# Controls when the action will run. Triggers the workflow on push
+# events but only for the stable branch
+on:
+  push:
+    branches:
+      - stable
+
+# Publishes Stable builds with the dist tag of "stable"
+jobs:
+  # This workflow contains a single job called "publish"
+  publish:
+    name: Stable build publish
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      # Caches NPM files
+      - name: Cache NPM files
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      # Sets up Node v12
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+          registry-url: 'https://npm.pkg.github.com'
+
+      # NPM ci init
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
+
+      # Git config
+      - run: git config --global user.email "beltran.caliz@washpost.com" && git config --global user.name "beltrancaliz"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PERSONAL_AUTH_TOKEN }}
+      
+      # Prerelease (tests and lint)
+      - run: npm version prerelease --preid=stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      # Publish
+      - run: npm publish --tag stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Push tag
+      - run: git push origin stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ In the future, this will be hosted. To build, see [documentation](https://storyb
 
 ## How To Publish
 
+Publishing new Engine Theme SDK releases happens automatically through Github actions. Whenever a push happens in any of these branches, a new version will be created with its corresponding dist tag:
+- canary
+- beta
+- stable
+
+You can view the status of these workflows [here](https://github.com/WPMedia/engine-theme-sdk/actions).
+
+## How To Manually Publish
+
+We strongly encourage sticking to our automated publishing process, however if for any reason a manual publish is needed, follow these steps:
+
 1. Pull the latest `canary` branch. 
 
 `git checkout canary`


### PR DESCRIPTION
## Description
Added a Github action to automate Engine Theme SDK stable releases. This runs on every push to the stable branch. Documentation is updated to reflect both the automated and manual processes.

## Jira Ticket
- [PEN-1298](https://arcpublishing.atlassian.net/browse/PEN-1298)

## Acceptance Criteria
On merge into stable branch name, should publish to stable tag. Same with canary and stable branches and tags 

## Test Steps
Push or make a PR against the stable branch and see the action being triggered and successfully publishing a new Engine Theme SDK version (run `npm view @wpmedia/engine-theme-sdk` to verify)

## Effect Of Changes
### Before
Engine Theme SDK stable releases have to be done by manually running publishing commands 

### After
Engine Theme SDK stable releases are now done automatically through a Github action. This reduces chances of errors like a forgotten local tag that wasn't pushed.

## Dependencies or Side Effects
None

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
