### PR TITLE
Quick fix storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<script defer src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,0 @@
-<script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script>


### PR DESCRIPTION
powa script seems to be affecting storybook's build of initial page load 
added defer to wait for page load for script 

before: 
<img width="1171" alt="Screen Shot 2020-11-02 at 17 56 38" src="https://user-images.githubusercontent.com/5950956/97932074-b9582a80-1d34-11eb-93ff-9cb1de94d91c.png">

![image](https://user-images.githubusercontent.com/5950956/97931918-54043980-1d34-11eb-9884-811d85b51f42.png)
not building and spinning screen 

after: 

working as expected and building the stories related

<img width="638" alt="Screen Shot 2020-11-02 at 18 03 20" src="https://user-images.githubusercontent.com/5950956/97932627-1c968c80-1d36-11eb-863d-75f45c2da16a.png">
