### PR TITLE
[PEN-1461] Quasi revert url compression

### DIFF
--- a/src/components/Image/SourceHandler.test.tsx
+++ b/src/components/Image/SourceHandler.test.tsx
@@ -5,6 +5,7 @@ import SourceHandler from './SourceHandler';
 describe('image source handler component', () => {
   const imageSource = 'www.hey.com/ffdfdf';
   const resizerURL = 'www.hey.resizer.com/';
+
   it('returns well-formed source tag if correct dimension image passed in', () => {
     const wrapper = shallow(<SourceHandler
       width={100}
@@ -13,11 +14,13 @@ describe('image source handler component', () => {
       imageSourceWithoutProtocol={imageSource}
       breakpointWidth={200}
       resizerURL={resizerURL}
+      compressedParams={false}
     />);
     expect(wrapper.find('source').prop('media')).toBe('screen and (min-width: 200px)');
 
     expect(wrapper.html()).toBe('<source srcSet="www.hey.resizer.com/correct-image.jpg=/100x100/www.hey.com/ffdfdf" media="screen and (min-width: 200px)"/>');
   });
+
   it('returns a null render if no matching dimension found', () => {
     const wrapper = shallow(<SourceHandler
       width={100}
@@ -27,11 +30,29 @@ describe('image source handler component', () => {
       imageSourceWithoutProtocol={imageSource}
       breakpointWidth={200}
       resizerURL={resizerURL}
+      compressedParams={false}
     />);
 
     expect(wrapper.html()).not.toBe('<source srcset="www.hey.resizer.com/correct-image.jpg=/100x100/www.hey.com/ffdfdf" media="screen and (min-width: 200px)">');
     expect(wrapper.html()).toBe(null);
     expect(wrapper.text()).toBe('');
     // wanted to use empty render here but not supported in this version of jest, nor on shallow
+  });
+
+  describe('when compressedParams is true', () => {
+    it('returns well-formed source tag if correct dimension image passed in', () => {
+      const wrapper = shallow(<SourceHandler
+        width={100}
+        height={100}
+        resizedImageOptions={{ '100x100': 'correct-image.jpg' }}
+        imageSourceWithoutProtocol={imageSource}
+        breakpointWidth={200}
+        resizerURL={resizerURL}
+        compressedParams
+      />);
+      expect(wrapper.find('source').prop('media')).toBe('screen and (min-width: 200px)');
+
+      expect(wrapper.html()).toBe('<source srcSet="www.hey.resizer.com/correct-image.jpg=/100x100/www.hey.com/ffdfdf" media="screen and (min-width: 200px)"/>');
+    });
   });
 });

--- a/src/components/Image/SourceHandler.tsx
+++ b/src/components/Image/SourceHandler.tsx
@@ -10,6 +10,7 @@ interface SourceImageProps {
   imageSourceWithoutProtocol: string;
   resizerURL: string;
   breakpointWidth: number;
+  compressedParams: boolean;
 }
 
 const SourceHandler: React.FC<SourceImageProps> = (props) => {
@@ -20,6 +21,7 @@ const SourceHandler: React.FC<SourceImageProps> = (props) => {
     imageSourceWithoutProtocol,
     resizerURL,
     breakpointWidth,
+    compressedParams,
   } = props;
 
   const interpolatedWidthHeight = `${width}x${height}`;
@@ -38,7 +40,7 @@ const SourceHandler: React.FC<SourceImageProps> = (props) => {
     <>
       <source
         // using src with picture tag parent is deprecated via console info warning
-        srcSet={buildThumborURL(resizedImageOptions[`${width}x${height}`], `${width}x${height}`, imageSourceWithoutProtocol, resizerURL)}
+        srcSet={buildThumborURL(resizedImageOptions[`${width}x${height}`], `${width}x${height}`, imageSourceWithoutProtocol, resizerURL, compressedParams)}
         media={`screen and (min-width: ${breakpointWidth}px)`}
       />
     </>

--- a/src/components/Image/image.test.jsx
+++ b/src/components/Image/image.test.jsx
@@ -69,4 +69,31 @@ describe('image component', () => {
 
     expect(wrapper.find('SourceHandler').length).toBe(3);
   });
+
+  describe('when compressedThumborParams is set to true', () => {
+    it('should return various breakpoints with the widths', () => {
+
+      const wrapper = shallow(<Image
+        url={rawURL}
+        alt={alt}
+        smallWidth={smallWidth}
+        smallHeight={smallHeight}
+        mediumWidth={mediumWidth}
+        mediumHeight={mediumHeight}
+        largeWidth={largeWidth}
+        largeHeight={largeHeight}
+        lightBoxWidth={largeWidth}
+        lightBoxHeight={largeHeight}
+        resizedImageOptions={resizedParams}
+        resizerURL={resizerURL}
+        breakpoints={breakpoints}
+        compressedThumborParams
+      />);
+      const { src, alt: altProperty } = wrapper.find('img').props();
+      expect(src).toBe('https://fake.cdn.arcpublishing.com/resizer/sDwhmVtwayjjDJww8CvlWjpydGM=/274x154/filters:format(jpg):quality(70)/fake.s3.amazonaws.com/public/37UMUNYNOVCEJDZW5SBKBXNMO4.jpg');
+      expect(altProperty).toBe(alt);
+
+      expect(wrapper.find('SourceHandler').length).toBe(3);
+    });
+  });
 });

--- a/src/components/Image/image.test.jsx
+++ b/src/components/Image/image.test.jsx
@@ -72,7 +72,6 @@ describe('image component', () => {
 
   describe('when compressedThumborParams is set to true', () => {
     it('should return various breakpoints with the widths', () => {
-
       const wrapper = shallow(<Image
         url={rawURL}
         alt={alt}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -34,6 +34,7 @@ interface ImageProps {
   lightBoxWidth?: number;
   lightBoxHeight?: number;
   lazyOptions?: LazyProps;
+  compressedThumborParams?: boolean;
 }
 
 /*
@@ -63,6 +64,7 @@ const StyledPicture = styled.picture`
 * @param {string} resizerURL - Link to the assigned resizer url for generating resized url
 * @param {object} breakpoints - Widths to determine small, med, and large breakpoints used
 * @param {object} lazyOptions - Object of offset values for each side (top, right, bottom, left)
+* @param {boolean} compressedThumborParam - Compresses the Thumbor compression params
     for the lazy-child moudles
 */
 const Image: React.FC<ImageProps> = ({
@@ -85,6 +87,7 @@ const Image: React.FC<ImageProps> = ({
     offsetRight: 0,
     offsetTop: 0,
   },
+  compressedThumborParams,
 }) => {
   if (typeof url === 'undefined') {
     return null;
@@ -154,6 +157,7 @@ const Image: React.FC<ImageProps> = ({
           imageSourceWithoutProtocol={imageSourceWithoutProtocol}
           resizerURL={resizerURL}
           breakpointWidth={largeBreakpoint}
+          compressedParams={compressedThumborParams}
         />
         <SourceHandler
           resizedImageOptions={resizedImageOptions}
@@ -162,6 +166,7 @@ const Image: React.FC<ImageProps> = ({
           imageSourceWithoutProtocol={imageSourceWithoutProtocol}
           resizerURL={resizerURL}
           breakpointWidth={mediumBreakpoint}
+          compressedParams={compressedThumborParams}
         />
         <SourceHandler
           resizedImageOptions={resizedImageOptions}
@@ -170,6 +175,7 @@ const Image: React.FC<ImageProps> = ({
           imageSourceWithoutProtocol={imageSourceWithoutProtocol}
           resizerURL={resizerURL}
           breakpointWidth={smallBreakpoint}
+          compressedParams={compressedThumborParams}
         />
         {
           typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'

--- a/src/components/Image/thumbor-image-url.test.ts
+++ b/src/components/Image/thumbor-image-url.test.ts
@@ -16,7 +16,7 @@ describe('thumbor image url function', () => {
     expect(buildThumborURL(targetImageKey, '100x100', imageSource, resizerURL)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100/filters:format(jpg):quality(70)/www.hey.com/ffdfdf');
   });
   it('returns a well-formed url image if filters have been assumed defaulted (with the cm=t param) to a format of jpg and quality of 70', () => {
-    expect(buildThumborURL(targetImageKeyCompressed, '100x100', imageSource, resizerURL)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100/filters:format(jpg):quality(70)/www.hey.com/ffdfdf');
+    expect(buildThumborURL(targetImageKeyCompressed, '100x100', imageSource, resizerURL, true)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100/filters:format(jpg):quality(70)/www.hey.com/ffdfdf');
   });
   it('retuns well-formed url with no filters', () => {
     expect(buildThumborURL(targetImageKeyNoFilters, '100x100', imageSource, resizerURL)).toBe('www.hey.resizer.com/r4YXPy4Eh2thx80bDTxRZM9Syhw=/100x100//www.hey.com/ffdfdf');

--- a/src/components/Image/thumbor-image-url.ts
+++ b/src/components/Image/thumbor-image-url.ts
@@ -3,6 +3,7 @@ const buildThumborURL = (
   targetDimension: string,
   imageSourceWithoutProtocol: string,
   resizerURL: string,
+  compressedParams?: boolean,
 ): string => {
   if (typeof targetImageKeyWithFilter === 'undefined' || resizerURL.length <= 1) {
     return '';
@@ -18,7 +19,7 @@ const buildThumborURL = (
    * 3) Convert the default format and quality params to thumbor params.
    */
   let uncompressedTarget = targetImageKeyWithFilter;
-  if (uncompressedTarget.indexOf(':cm=t') !== -1) {
+  if (uncompressedTarget.indexOf(':cm=t') !== -1 && compressedParams) {
     uncompressedTarget = uncompressedTarget.replace(':cm=t', ':format(jpg):quality(70)');
     uncompressedTarget = `/${uncompressedTarget}`;
   }


### PR DESCRIPTION
## Description
Added a param for URL compression. I don't remember why at this point.

## Jira Ticket
- [PEN-1461](https://arcpublishing.atlassian.net/browse/PEN-)

## Acceptance Criteria
Yeah, sure.

## Test Steps
Run locally and test images?

## Effect Of Changes
### Before
We did URL compression every time.

### After
There's a new param in case you want to opt in to URL compression.

## Dependencies or Side Effects
There's a new param that's only optional.

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
