### PR TITLE
PEN-438 nativo ad integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,7 @@
     "preversion": "npm run lint",
     "postpublish": "git push --tags",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "chromatic": "npx chromatic --project-token=pc32y518itq --exit-once-uploaded"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run chromatic"
-    }
+    "build-storybook": "build-storybook"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -1255,4 +1255,52 @@ describe('the meta data ', () => {
       noGlobalContent('');
     });
   });
+
+  describe('when page type is nativo-clp with globalContent', () => {
+    const metaValue = metaValues({
+      'page-type': 'nativo-clp',
+    });
+    const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+
+    it('must not have any twitter meta tags', () => {
+      expect(wrapper.find("meta[name^='twitter:']").length).toBe(0);
+    });
+
+    it('must not have any facebook meta tags', () => {
+      expect(wrapper.find("meta[name^='og:']").length).toBe(0);
+    });
+
+    it('must not have canonical tag', () => {
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(0);
+    });
+
+    it('must have required nativo tags', () => {
+      expect(wrapper.find('meta[content="IE=edge"]').prop('httpEquiv')).toEqual('X-UA-Compatible');
+      expect(wrapper.find('meta[name="robots"]').prop('content')).toEqual('noindex, nofollow');
+    });
+  });
+
+  describe('when page type is nativo-clp without globalContent', () => {
+    const metaValue = metaValues({
+      'page-type': 'nativo-clp',
+    });
+    const wrapper = wrapperGenerator(metaValue, null);
+
+    it('must not have any twitter meta tags', () => {
+      expect(wrapper.find("meta[name^='twitter:']").length).toBe(0);
+    });
+
+    it('must not have any facebook meta tags', () => {
+      expect(wrapper.find("meta[name^='og:']").length).toBe(0);
+    });
+
+    it('must not have canonical tag', () => {
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(0);
+    });
+
+    it('must have required nativo tags', () => {
+      expect(wrapper.find('meta[content="IE=edge"]').prop('httpEquiv')).toEqual('X-UA-Compatible');
+      expect(wrapper.find('meta[name="robots"]').prop('content')).toEqual('noindex, nofollow');
+    });
+  });
 });

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -108,6 +108,8 @@ const MetaData: React.FC<Props> = ({
   let searchMetaDataTags = null;
   let sectionMetaDataTags = null;
   let homepageMetaDataTags = null;
+  let nativoMetaDataTags = null;
+  let commonTagsOnPage = true;
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
   const { getImgURL, getImgAlt } = require('./promoImageHelper');
@@ -313,6 +315,16 @@ const MetaData: React.FC<Props> = ({
     );
   } else if (pageType === 'homepage') {
     homepageMetaDataTags = <meta property="og:title" content={metaData.ogTitle} />;
+  } else if (pageType === 'nativo-clp') {
+    /* Nativo ad integration */
+    /* this kind of page type can not render any social metadata */
+    commonTagsOnPage = false;
+    nativoMetaDataTags = (
+      <>
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="robots" content="noindex, nofollow" />
+      </>
+    );
   } else {
     sectionMetaDataTags = (
       <>
@@ -359,7 +371,8 @@ const MetaData: React.FC<Props> = ({
       {authorMetaDataTags}
       {searchMetaDataTags}
       {customMetaTags}
-      {twitterTags}
+      {commonTagsOnPage && twitterTags}
+      {nativoMetaDataTags}
     </>
   );
 };


### PR DESCRIPTION
## Description
added nativo ad integration

## Jira Ticket
- [PEN-438](https://arcpublishing.atlassian.net/browse/PEN-438)

## Acceptance Criteria
- A new boolean Theme Setting called nativoIntegration should be created. 
  - If nativoIntegration = true, then Nativo functionality as described below should be added to the site
  - If nativoIntegration = false or if it’s not present at all, then no Nativo functionality should be added. 
- If nativoIntegration = true, then the Nativo script should be added to all pages on the site, per Nativo’s instructions: https://pub-resources.nativo.com/docs/javascript-integration-process
- We’ll add a new page-type value called nativo-clp. If page-type=nativo-clp on a given page, then the following should happen, per Nativo’s instructions https://pub-resources.nativo.com/docs/javascript-integration-process#31-add-javascript-and-meta-tags-to-clp
- Nativo script is included in the page
  -All metadata is removed from this page, except for the following which are added (and should only be added to nativo-clp pages: 
  - `<meta http-equiv="X-UA-Compatible" content="IE=edge" />`
  - `<meta name="robots" content="noindex, nofollow" />`
- See existing Page Types documentation: https://corecomponents.arcpublishing.com/alc/arc-products/themes/user-docs/page-template-guide/page-types/

## Test Steps
- when the new site's property `nativoIntegration` is added to a site, the Nativo script must be inserted on the page header for that site
- create a new page template and add the meta values `page-type: nativo-clp`
  - when this page is rendered, no social metadata must be added to the page and two meta tags must be inserted per Nativo request, check AC

## Effect Of Changes
### Before
is new functionality

### After
<img width="793" alt=" 2020-11-17-12 47 49" src="https://user-images.githubusercontent.com/9757/99414061-3064f580-28d5-11eb-86b5-fad6a9501a1e.png">

## Dependencies or Side Effects
- a new property on FP blocks.json site properties labeled `nativoIntegration: true`
- PR from `fusion-news-themes-blocks` https://github.com/WPMedia/fusion-news-theme-blocks/pull/561

## Review Checklist
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
