### PR TITLE
[PEN-1461] Added fixes for URL compression

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -87,6 +87,7 @@ interface GalleryProps {
   autoplayPhrase?: string;
   pausePhrase?: string;
   pageCountPhrase?: (current: number, total: number) => string;
+  compressedThumborParams?: boolean;
 }
 
 declare interface EventOptionsInterface {
@@ -102,6 +103,7 @@ const Gallery: React.FC<GalleryProps> = ({
   autoplayPhrase,
   pausePhrase,
   pageCountPhrase,
+  compressedThumborParams = false,
 }) => {
   const galleryRef = useRef(null);
   const [page, setPage] = useState(0);
@@ -290,6 +292,7 @@ const Gallery: React.FC<GalleryProps> = ({
               resizedImageOptions={imgContent.resized_params}
               breakpoints={imgContent.breakpoints || {}}
               resizerURL={resizerURL}
+              compressedThumborParams={compressedThumborParams}
             />
           </ImageWrapper>
         ))}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -123,8 +123,11 @@ const Image: React.FC<ImageProps> = ({
   // if url passed in directly without resized params
   if (typeof resizedImageOptions === 'undefined' || typeof resizedImageOptions[`${largeWidth}x${largeHeight}`] === 'undefined') {
     // todo: remove for prod
-    console.error(`no resized options found for url: ${url}.`);
-    console.error('Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.');
+    if (Fusion?.isAdmin) {
+      console.error(`no resized options found for url: ${url}.`);
+      console.error('Please use resized options to save money on serving bigger images than necessary. Consider using resizer content source block or adding the resizer block to content source transform.');
+    }
+
     return (
       <img
         // will not serve image raw
@@ -182,7 +185,7 @@ const Image: React.FC<ImageProps> = ({
             ? (
               <img
                 alt={alt}
-                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL, compressedThumborParams)}
                 width={largeWidth}
                 height={largeHeight}
               />
@@ -190,9 +193,9 @@ const Image: React.FC<ImageProps> = ({
             : (
               <img
                 alt={alt}
-                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL, compressedThumborParams)}
                 // lightbox component reads from this data attribute
-                data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
+                data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL, compressedThumborParams)}
                 width={largeWidth}
                 height={largeHeight}
               />

--- a/src/components/Image/thumbor-image-url.ts
+++ b/src/components/Image/thumbor-image-url.ts
@@ -31,7 +31,7 @@ const buildThumborURL = (
     return `${resizerURL}/${targetImageKey}=${imageFilter}${imageSourceWithoutProtocol}`;
   }
 
-  return `${resizerURL}${targetImageKey}=/${targetDimension}/${imageFilter}${imageSourceWithoutProtocol}`;
+  return `${resizerURL}/${targetImageKey}=/${targetDimension}/${imageFilter}${imageSourceWithoutProtocol}`;
 };
 
 export default buildThumborURL;

--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -311,3 +311,31 @@ import { Image } from '@wpmedia/engine-theme-sdk';
         />
     </Story>
 </Preview>
+
+### Compress resizedParams
+<Preview>
+    <Story name="compress params">
+        <Image
+            url={'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/DSGZ5WCVBZHRXDB3JT4K5TWL4Y.jpg'}
+            alt={'Aerial view of bridge'}
+            smallWidth={84}
+            smallHeight={56}
+            mediumWidth={84}
+            mediumHeight={56}
+            largeWidth={84}
+            largeHeight={56}
+            resizedImageOptions={{
+                "84x56": "W-KzYlliwcoZ7IR5-g6LrRsp63Q=filters:cm=t/"
+            }}
+            resizerURL={'https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer'}
+            breakpoints={{
+                small: 420,
+                medium: 768,
+                large: 992,
+            }}
+            lightBoxWidth={274}
+            lightBoxHeight={154}
+            compressedThumborParams={true}
+        />
+    </Story>
+</Preview>

--- a/types/fusion.d.ts
+++ b/types/fusion.d.ts
@@ -13,4 +13,5 @@ declare module 'fusion:themes';
 
 declare const Fusion: {
     deployment?: string;
+    isAdmin?: boolean;
 };


### PR DESCRIPTION
## Description
Made Thumbor URLs work (I think).

If tests are broken then that's too bad.

## Jira Ticket
- [PEN-1461](https://arcpublishing.atlassian.net/browse/PEN-1461)

## Acceptance Criteria
Not sure

## Test Steps
RUN IT LOCALLY

In your blocks.json you need to set one of your sites to have the property `shouldCompress` set to `true` and at least one other site where it is set to `false` or is unset. Make sure both of those sites work when loading one of our pages with all the blocks.

## Effect Of Changes
### Before

### After

## Dependencies or Side Effects
See the blocks.json information in the testing steps.

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.


