### PR TITLE
feat: Handle compressed params by the cm=t not election

### DIFF
--- a/src/components/Image/SourceHandler.test.tsx
+++ b/src/components/Image/SourceHandler.test.tsx
@@ -14,7 +14,6 @@ describe('image source handler component', () => {
       imageSourceWithoutProtocol={imageSource}
       breakpointWidth={200}
       resizerURL={resizerURL}
-      compressedParams={false}
     />);
     expect(wrapper.find('source').prop('media')).toBe('screen and (min-width: 200px)');
 
@@ -30,29 +29,11 @@ describe('image source handler component', () => {
       imageSourceWithoutProtocol={imageSource}
       breakpointWidth={200}
       resizerURL={resizerURL}
-      compressedParams={false}
     />);
 
     expect(wrapper.html()).not.toBe('<source srcset="www.hey.resizer.com/correct-image.jpg=/100x100/www.hey.com/ffdfdf" media="screen and (min-width: 200px)">');
     expect(wrapper.html()).toBe(null);
     expect(wrapper.text()).toBe('');
     // wanted to use empty render here but not supported in this version of jest, nor on shallow
-  });
-
-  describe('when compressedParams is true', () => {
-    it('returns well-formed source tag if correct dimension image passed in', () => {
-      const wrapper = shallow(<SourceHandler
-        width={100}
-        height={100}
-        resizedImageOptions={{ '100x100': 'correct-image.jpg' }}
-        imageSourceWithoutProtocol={imageSource}
-        breakpointWidth={200}
-        resizerURL={resizerURL}
-        compressedParams
-      />);
-      expect(wrapper.find('source').prop('media')).toBe('screen and (min-width: 200px)');
-
-      expect(wrapper.html()).toBe('<source srcSet="www.hey.resizer.com/correct-image.jpg=/100x100/www.hey.com/ffdfdf" media="screen and (min-width: 200px)"/>');
-    });
   });
 });

--- a/src/components/Image/SourceHandler.tsx
+++ b/src/components/Image/SourceHandler.tsx
@@ -10,7 +10,6 @@ interface SourceImageProps {
   imageSourceWithoutProtocol: string;
   resizerURL: string;
   breakpointWidth: number;
-  compressedParams: boolean;
 }
 
 const SourceHandler: React.FC<SourceImageProps> = (props) => {
@@ -21,7 +20,6 @@ const SourceHandler: React.FC<SourceImageProps> = (props) => {
     imageSourceWithoutProtocol,
     resizerURL,
     breakpointWidth,
-    compressedParams,
   } = props;
 
   const interpolatedWidthHeight = `${width}x${height}`;
@@ -40,7 +38,7 @@ const SourceHandler: React.FC<SourceImageProps> = (props) => {
     <>
       <source
         // using src with picture tag parent is deprecated via console info warning
-        srcSet={buildThumborURL(resizedImageOptions[`${width}x${height}`], `${width}x${height}`, imageSourceWithoutProtocol, resizerURL, compressedParams)}
+        srcSet={buildThumborURL(resizedImageOptions[`${width}x${height}`], `${width}x${height}`, imageSourceWithoutProtocol, resizerURL)}
         media={`screen and (min-width: ${breakpointWidth}px)`}
       />
     </>

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -34,7 +34,6 @@ interface ImageProps {
   lightBoxWidth?: number;
   lightBoxHeight?: number;
   lazyOptions?: LazyProps;
-  compressedThumborParams?: boolean;
 }
 
 /*
@@ -64,7 +63,6 @@ const StyledPicture = styled.picture`
 * @param {string} resizerURL - Link to the assigned resizer url for generating resized url
 * @param {object} breakpoints - Widths to determine small, med, and large breakpoints used
 * @param {object} lazyOptions - Object of offset values for each side (top, right, bottom, left)
-* @param {boolean} compressedThumborParam - Compresses the Thumbor compression params
     for the lazy-child moudles
 */
 const Image: React.FC<ImageProps> = ({
@@ -87,7 +85,6 @@ const Image: React.FC<ImageProps> = ({
     offsetRight: 0,
     offsetTop: 0,
   },
-  compressedThumborParams,
 }) => {
   if (typeof url === 'undefined') {
     return null;
@@ -157,7 +154,6 @@ const Image: React.FC<ImageProps> = ({
           imageSourceWithoutProtocol={imageSourceWithoutProtocol}
           resizerURL={resizerURL}
           breakpointWidth={largeBreakpoint}
-          compressedParams={compressedThumborParams}
         />
         <SourceHandler
           resizedImageOptions={resizedImageOptions}
@@ -166,7 +162,6 @@ const Image: React.FC<ImageProps> = ({
           imageSourceWithoutProtocol={imageSourceWithoutProtocol}
           resizerURL={resizerURL}
           breakpointWidth={mediumBreakpoint}
-          compressedParams={compressedThumborParams}
         />
         <SourceHandler
           resizedImageOptions={resizedImageOptions}
@@ -175,14 +170,13 @@ const Image: React.FC<ImageProps> = ({
           imageSourceWithoutProtocol={imageSourceWithoutProtocol}
           resizerURL={resizerURL}
           breakpointWidth={smallBreakpoint}
-          compressedParams={compressedThumborParams}
         />
         {
           typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
             ? (
               <img
                 alt={alt}
-                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL, compressedThumborParams)}
+                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
                 width={largeWidth}
                 height={largeHeight}
               />
@@ -190,9 +184,9 @@ const Image: React.FC<ImageProps> = ({
             : (
               <img
                 alt={alt}
-                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL, compressedThumborParams)}
+                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
                 // lightbox component reads from this data attribute
-                data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL, compressedThumborParams)}
+                data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
                 width={largeWidth}
                 height={largeHeight}
               />

--- a/src/components/Image/thumbor-image-url.ts
+++ b/src/components/Image/thumbor-image-url.ts
@@ -3,7 +3,6 @@ const buildThumborURL = (
   targetDimension: string,
   imageSourceWithoutProtocol: string,
   resizerURL: string,
-  compressedParams?: boolean,
 ): string => {
   if (typeof targetImageKeyWithFilter === 'undefined' || resizerURL.length <= 1) {
     return '';
@@ -19,7 +18,7 @@ const buildThumborURL = (
    * 3) Convert the default format and quality params to thumbor params.
    */
   let uncompressedTarget = targetImageKeyWithFilter;
-  if (uncompressedTarget.indexOf(':cm=t') !== -1 && compressedParams) {
+  if (uncompressedTarget.indexOf(':cm=t') !== -1) {
     uncompressedTarget = uncompressedTarget.replace(':cm=t', ':format(jpg):quality(70)');
     uncompressedTarget = `/${uncompressedTarget}`;
   }


### PR DESCRIPTION
- Handle cm=t not by electing to do, but just by handling the input as is
- we want the engine theme sdk to not need to know fusion/site properties 
- just handle whatever resized params it gets 

opt in with cm=t in the content source

![Screen Shot 2020-11-20 at 11 16 06](https://user-images.githubusercontent.com/5950956/99829325-c9884c00-2b21-11eb-82bb-88e5c1ec9a47.png)

opt out
![Screen Shot 2020-11-20 at 11 15 51](https://user-images.githubusercontent.com/5950956/99830476-5da6e300-2b23-11eb-97fd-3a779c369cb8.png)


