### PR TITLE
Added 'extractVideoEmbedFromStory()' helper function & unit tests

### DIFF
--- a/src/utils/extractVideoEmbedFromStory.test.ts
+++ b/src/utils/extractVideoEmbedFromStory.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import extractVideoEmbedFromStory from './extractVideoEmbedFromStory';
 
 const contentTypeImageBasicPromo = {

--- a/src/utils/extractVideoEmbedFromStory.test.ts
+++ b/src/utils/extractVideoEmbedFromStory.test.ts
@@ -1,0 +1,70 @@
+import extractVideoEmbedFromStory from './extractVideoEmbedFromStory';
+
+const contentTypeImageBasicPromo = {
+  type: 'story',
+  promo_items: {
+    basic: {
+      type: 'image',
+    },
+  },
+};
+const contentTypeImageLeadPromo = {
+  type: 'story',
+  promo_items: {
+    lead_art: {
+      type: 'image',
+    },
+  },
+};
+const contentTypeVideo = {
+  type: 'video',
+  embed_html: '<div class="somehtml"></div>',
+};
+const contentTypeVideoPromo = {
+  type: 'story',
+  promo_items: {
+    lead_art: {
+      ...contentTypeVideo,
+    },
+  },
+};
+
+describe('extractVideoEmbedFromStory()', () => {
+  describe('when content type is "story"', () => {
+    it('should return "undefined" when content has non-"video" basic art', () => {
+      const vidEmbed = extractVideoEmbedFromStory(contentTypeImageBasicPromo);
+      expect(vidEmbed).not.toBeDefined();
+    });
+
+    it('should return "undefined" when content has non-"video" lead art', () => {
+      const vidEmbed = extractVideoEmbedFromStory(contentTypeImageLeadPromo);
+      expect(vidEmbed).not.toBeDefined();
+    });
+
+    it('should return "embed_html" when content has "video" lead art', () => {
+      const vidEmbed = extractVideoEmbedFromStory(contentTypeVideoPromo);
+      expect(vidEmbed).toBeDefined();
+      expect(vidEmbed).toEqual(contentTypeVideo.embed_html);
+    });
+  });
+
+  describe('when content type is "video"', () => {
+    it('should return "undefined" when embed does not exist', () => {
+      const vidEmbed = extractVideoEmbedFromStory({ type: 'video' });
+      expect(vidEmbed).not.toBeDefined();
+    });
+
+    it('should return "embed_html" when embed exists', () => {
+      const vidEmbed = extractVideoEmbedFromStory(contentTypeVideo);
+      expect(vidEmbed).toBeDefined();
+      expect(vidEmbed).toEqual(contentTypeVideo.embed_html);
+    });
+  });
+
+  describe('when content is undefined', () => {
+    it('should return "undefined" when no valid content', () => {
+      const vidEmbed = extractVideoEmbedFromStory(undefined);
+      expect(vidEmbed).not.toBeDefined();
+    });
+  });
+});

--- a/src/utils/extractVideoEmbedFromStory.ts
+++ b/src/utils/extractVideoEmbedFromStory.ts
@@ -1,16 +1,30 @@
-const extractVideoEmbedFromStory = (content) => {
-  if (!content || !content.type) return undefined;
-  const contentEl = (
-    (content.type === 'video' && content) || (
-      content.type === 'story'
-      && content.promo_items
+interface SchemaANS {
+  type: string;
+  promo_items?: {
+    lead_art?: {
+      type?: string;
+      embed_html?: string;
+    };
+  };
+  embed_html?: string;
+}
+
+const extractVideoEmbedFromStory = (content: SchemaANS): string => {
+  if (content && content.type === 'video') {
+    return content.embed_html;
+  }
+
+  if (
+    (content && content.type === 'story') && (
+      content.promo_items
       && content.promo_items.lead_art
-      && content.promo_items.lead_art.type
       && content.promo_items.lead_art.type === 'video'
-        ? content.promo_items.lead_art : undefined
     )
-  );
-  return contentEl ? contentEl.embed_html : undefined;
+  ) {
+    return content.promo_items.lead_art.embed_html;
+  }
+
+  return undefined;
 };
 
 export default extractVideoEmbedFromStory;

--- a/src/utils/extractVideoEmbedFromStory.ts
+++ b/src/utils/extractVideoEmbedFromStory.ts
@@ -1,0 +1,16 @@
+const extractVideoEmbedFromStory = (content) => {
+  if (!content || !content.type) return undefined;
+  const contentEl = (
+    (content.type === 'video' && content) || (
+      content.type === 'story'
+      && content.promo_items
+      && content.promo_items.lead_art
+      && content.promo_items.lead_art.type
+      && content.promo_items.lead_art.type === 'video'
+        ? content.promo_items.lead_art : undefined
+    )
+  );
+  return contentEl ? contentEl.embed_html : undefined;
+};
+
+export default extractVideoEmbedFromStory;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as localizeDate } from './localizeDate';
 export { default as localizeDateTime } from './localizeDateTime';
+export { default as extractVideoEmbedFromStory } from './extractVideoEmbedFromStory';


### PR DESCRIPTION
## Description
Added `extractVideoEmbedFromStory()` helper function

## Jira Ticket
- [PEN-](https://arcpublishing.atlassian.net/browse/PEN-1493)

## Acceptance Criteria
_copy from ticket_

## Test Steps
Test together with steps in https://github.com/WPMedia/fusion-news-theme-blocks/pull/584

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps above are working
- [X] Confirmed there are no linter errors
- [X] Confirmed this PR has reasonable code coverage
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
