### PR TITLE
PEN-1588 Support for Norwegian, French in date localizations

### DIFF
--- a/src/utils/localizeDate.ts
+++ b/src/utils/localizeDate.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'));
+const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'));
 
 const localizeDate = (date,
   dateFormat = '%B %d, %Y',
@@ -11,6 +11,12 @@ const localizeDate = (date,
   switch (language) {
     case 'sv':
       locale = 'sv_SE';
+      break;
+    case 'fr':
+      locale = 'fr_FR';
+      break;
+    case 'no':
+      locale = 'nb_NO';
       break;
     default:
       locale = 'en_US';

--- a/src/utils/localizeDateTime.ts
+++ b/src/utils/localizeDateTime.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'));
+const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'));
 
 const localizeDateTime = (date,
   dateFormat = '%B %d, %Y at %l:%M %P %Z',
@@ -11,6 +11,12 @@ const localizeDateTime = (date,
   switch (language) {
     case 'sv':
       locale = 'sv_SE';
+      break;
+    case 'fr':
+      locale = 'fr_FR';
+      break;
+    case 'no':
+      locale = 'nb_NO';
       break;
     default:
       locale = 'en_US';


### PR DESCRIPTION
## Description
_Information about what you changed for this PR_
Add France and Norwegian into localizeDate and localizeDateTime

## Jira Ticket
- [PEN-1588](https://arcpublishing.atlassian.net/browse/PEN-1588)

## Acceptance Criteria
_copy from ticket_

Customers can set the language format for their dates to Norwegian and French (in addition to English and Swedish, which are already supported), and the respective language is used for dates on the website

Tests and documentation are updated to cover this functionality 

## Test Steps
- Add test steps a reviewer must complete to test this PR

1. The Sun and The Prophet are already set up to use French and Norwegian locale respectively in our blocks.json for Core Components: https://github.com/WPMedia/Fusion-News-Theme/blob/master/blocks.json - Connect to preview – please also update their Date localization language Theme Settings to use French (fr) and Norwegian (no) respectively 

2. Verify that the date strings for these websites now uses French and Norwegian words in the Masthead date (rather than English) 

    - The Sun / French: décembre

      -- https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=the-sun

    - The Prophet / Norwegian: desember

      -- https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=the-prophet

3. Verify that the date strings on articles also use the respective languages. (E.g. on the example screenshot I shared above where the months show as January, it should be janvier for French and januar for Norwegian) 

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
