### PR TITLE
Fix for 'extractVideoEmbedFromStory' build error

### DIFF
--- a/src/utils/extractVideoEmbedFromStory.ts
+++ b/src/utils/extractVideoEmbedFromStory.ts
@@ -5,6 +5,9 @@ interface SchemaANS {
       type?: string;
       embed_html?: string;
     };
+    basic?: {
+      type?: string;
+    };
   };
   embed_html?: string;
 }


### PR DESCRIPTION
## Description
Fix for 'extractVideoEmbedFromStory' build error caused by test data shape not being included in 'SchemaANS'

## Jira Ticket
- [PEN-1493](https://arcpublishing.atlassian.net/browse/PEN-1493)

## Acceptance Criteria
_copy from ticket_

## Test Steps
Run `npm run build`, `npm run test:coverage`, `npm run lint` and make sure there are no errors and all tests pass

## Effect Of Changes
### Before
Build was failing on `extractVideoEmbedFromStory` unit test data

### After
Build no longer failing

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps above are working
- [X] Confirmed there are no linter errors
- [X] Confirmed this PR has reasonable code coverage
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
