### PR TITLE
PEN-1617 Issue expanded gallery

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -30,11 +30,11 @@ import React, { useRef, useState, useEffect } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import PropTypes from 'prop-types';
 import Image from '../Image';
+import buildThumborURL from '../Image/thumbor-image-url';
 import Lightbox from '../Lightbox/index';
 import ImageMetadata from '../ImageMetadata';
 import useInterval from './setInterval';
 import EventEmitter from '../EventEmitter';
-import buildThumborURL from '../image/thumbor-image-url';
 
 import {
   GalleryDiv,

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -257,14 +257,14 @@ const Gallery: React.FC<GalleryProps> = ({
       }
     }
 
-    // querySelectorAll looks like not rendered next image 
+    // querySelectorAll looks like not rendered next image
     // and we getting empty data for lightBox
-    if(galleryElements[pageNo]){
+    if (galleryElements[pageNo]) {
       const galleryElement = galleryElements[pageNo];
       const imageSourceWithoutProtocol = galleryElement.url.replace('https://', '');
-      const imageSrc = buildThumborURL(galleryElement.resized_params[`${1600}x${0}`], `${1600}x${0}`
-        , imageSourceWithoutProtocol
-        , resizerURL);
+      const imageSrc = buildThumborURL(galleryElement.resized_params[`${1600}x${0}`], `${1600}x${0}`,
+        imageSourceWithoutProtocol,
+        resizerURL);
       return imageSrc;
     }
 

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -34,6 +34,7 @@ import Lightbox from '../Lightbox/index';
 import ImageMetadata from '../ImageMetadata';
 import useInterval from './setInterval';
 import EventEmitter from '../EventEmitter';
+import buildThumborURL from '../image/thumbor-image-url';
 
 import {
   GalleryDiv,
@@ -256,10 +257,15 @@ const Gallery: React.FC<GalleryProps> = ({
       }
     }
 
-    // querySelectorAll looks like not rendered image 
-    // and we getting empty data
+    // querySelectorAll looks like not rendered next image 
+    // and we getting empty data for lightBox
     if(galleryElements[pageNo]){
-      return galleryElements[pageNo].url;
+      const galleryElement = galleryElements[pageNo];
+      const imageSourceWithoutProtocol = galleryElement.url.replace('https://', '');
+      const imageSrc = buildThumborURL(galleryElement.resized_params[`${1600}x${0}`], `${1600}x${0}`
+        , imageSourceWithoutProtocol
+        , resizerURL);
+      return imageSrc;
     }
 
     return '';

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -255,6 +255,13 @@ const Gallery: React.FC<GalleryProps> = ({
         return array[pageNo].dataset.lightbox;
       }
     }
+
+    // querySelectorAll looks like not rendered image 
+    // and we getting empty data
+    if(galleryElements[pageNo]){
+      return galleryElements[pageNo].url;
+    }
+
     return '';
   };
 

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1704,11 +1704,24 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
           </LightboxImage>,
         );
       };
+
       const addItem = (srcType, imageClass, baseStyle = {}): void => {
         const DisplayItem = this.props[srcType];
         if (!DisplayItem) {
+            displayItems.push(
+              <LightboxImage
+                as="div"
+                className={imageClass}
+                style={baseStyle}
+                key={this.props[srcType] + keyEndings[srcType]}
+              >
+                <ErrorContainer className="errorContainer">{this.props.imageLoadErrorMessage}</ErrorContainer>
+              </LightboxImage>,
+            );
+
           return;
         }
+
         if (typeof DisplayItem === 'string') {
           addImage(srcType, imageClass, baseStyle);
         }

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1708,16 +1708,16 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
       const addItem = (srcType, imageClass, baseStyle = {}): void => {
         const DisplayItem = this.props[srcType];
         if (!DisplayItem) {
-            displayItems.push(
-              <LightboxImage
-                as="div"
-                className={imageClass}
-                style={baseStyle}
-                key={this.props[srcType] + keyEndings[srcType]}
-              >
-                <ErrorContainer className="errorContainer">{this.props.imageLoadErrorMessage}</ErrorContainer>
-              </LightboxImage>,
-            );
+          displayItems.push(
+            <LightboxImage
+              as="div"
+              className={imageClass}
+              style={baseStyle}
+              key={this.props[srcType] + keyEndings[srcType]}
+            >
+              <ErrorContainer className="errorContainer">{this.props.imageLoadErrorMessage}</ErrorContainer>
+            </LightboxImage>,
+          );
 
           return;
         }


### PR DESCRIPTION
## Description
When the user presses Expand on a gallery and advances through a couple more images, they will see a black screen with a loading icon, like the image is still loading: 

https://share.getcloudapp.com/GGu2zRKn

https://corecomponents-the-gazette-prod.cdn.arcpublishing.com/gallery/2020/02/06/the-scene-as-astronaut-christina-koch-returns-to-earth-after-historic-tour-aboard-the-international-space-station/

## Jira Ticket
- [PEN-1617](https://arcpublishing.atlassian.net/browse/PEN-1617)

## Acceptance Criteria
When a reader is viewing images in Expanded mode, images should be visible once they’ve loaded on the page – they should not have to exit Expanded Mode to see the image. 

## Test Steps
https://share.getcloudapp.com/GGu2zRKn

https://corecomponents-the-gazette-prod.cdn.arcpublishing.com/gallery/2020/02/06/the-scene-as-astronaut-christina-koch-returns-to-earth-after-historic-tour-aboard-the-international-space-station/

## Effect Of Changes
### Before
Image was not loaded properly and showed blank page instead

### After
It was an issue in 2 components. Gallery and Lightbox. Gallery passed empty imageUrl to lightbox and lightbox showed blank page. I resolved issues in both gallery (it should not pass empty url) and in Lightbox (even if it pass, lightbox will show caption "error loading image", but not blank page)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
