### PR TITLE
PEN-1631 Support for "Hide photographer" and "Vanity photographer" in Composer

### DIFF
--- a/src/components/ImageMetadata/index.test.tsx
+++ b/src/components/ImageMetadata/index.test.tsx
@@ -160,4 +160,78 @@ describe('the ImageMetadata component', () => {
       expect(wrapper.isEmptyRender()).toBe(true);
     });
   });
+
+  describe('when a vanityCredits is passed in the props', () => {
+    it('should hide photographer and credit on image', () => {
+      const wrapper = shallow(<ImageMetadata
+        subtitle="ffffg"
+        caption="ttttu"
+        credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
+        vanityCredits={{ by: [{}], affiliation: [{}] }}
+      />);
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').first().text()).toBe('ffffg ');
+      expect(wrapper.text()).toBe('ffffg ttttu ');
+    });
+
+    it('should override photographer and credit on image using vanity credits info', () => {
+      const wrapper = shallow(<ImageMetadata
+        subtitle="ffffg"
+        caption="ttttu"
+        credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
+        vanityCredits={{ by: [{ name: 'vanity photograher' }], affiliation: [{ name: 'vanity credit' }] }}
+      />);
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').first().text()).toBe('ffffg ');
+      expect(wrapper.text()).toBe('ffffg ttttu (vanity photograher/vanity credit)');
+    });
+
+    it('should override photographer on image using vanity credits info', () => {
+      const wrapper = shallow(<ImageMetadata
+        subtitle="ffffg"
+        caption="ttttu"
+        credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
+        vanityCredits={{ by: [{ name: 'vanity photograher' }] }}
+      />);
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').first().text()).toBe('ffffg ');
+      expect(wrapper.text()).toBe('ffffg ttttu (vanity photograher/affff)');
+    });
+
+    it('should override credit on image using vanity credits info', () => {
+      const wrapper = shallow(<ImageMetadata
+        subtitle="ffffg"
+        caption="ttttu"
+        credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
+        vanityCredits={{ affiliation: [{ name: 'vanity credit' }] }}
+      />);
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').first().text()).toBe('ffffg ');
+      expect(wrapper.text()).toBe('ffffg ttttu (bbbyyy/vanity credit)');
+    });
+
+    it('should show photographer and hide credit on image using vanity credits info', () => {
+      const wrapper = shallow(<ImageMetadata
+        subtitle="ffffg"
+        caption="ttttu"
+        credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
+        vanityCredits={{ by: [{ name: 'vanity photograher' }], affiliation: [{}] }}
+      />);
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').first().text()).toBe('ffffg ');
+      expect(wrapper.text()).toBe('ffffg ttttu (vanity photograher)');
+    });
+
+    it('should hide photographer and show credit on image using vanity credits info', () => {
+      const wrapper = shallow(<ImageMetadata
+        subtitle="ffffg"
+        caption="ttttu"
+        credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
+        vanityCredits={{ by: [{}], affiliation: [{ name: 'vanity credit' }] }}
+      />);
+      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').first().text()).toBe('ffffg ');
+      expect(wrapper.text()).toBe('ffffg ttttu (vanity credit)');
+    });
+  });
 });

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -15,6 +15,10 @@ interface ImageMetadataProps {
     by?: ImageAttribution[];
     affiliation?: ImageAttribution[];
   };
+  vanityCredits?: {
+    by?: ImageAttribution[];
+    affiliation?: ImageAttribution[];
+  };
 }
 
 const MetadataParagraph = styled.p<{ primaryFont: string }>`
@@ -38,11 +42,20 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
   subtitle,
   caption,
   credits: { by = [{}], affiliation = [{}] } = {},
+  vanityCredits,
 }) => {
   const { arcSite } = useAppContext();
-  const photographer = by && by[0] && by[0].name;
-  const aff = affiliation && affiliation[0] && affiliation[0].name;
-
+  let photographer = by && by[0] && by[0].name;
+  let aff = affiliation && affiliation[0] && affiliation[0].name;
+  if (vanityCredits) {
+    const { by: vanityBy, affiliation: vanityAff } = vanityCredits;
+    if (vanityBy) {
+      photographer = (vanityBy[0] && vanityBy[0].name) || null;
+    }
+    if (vanityAff) {
+      aff = (vanityAff[0] && vanityAff[0].name) || null;
+    }
+  }
   const credits = (photographer || aff) && `(${[photographer, aff].filter((name) => name).join('/')})`;
 
   return !!(subtitle || caption || credits) && (
@@ -72,6 +85,11 @@ ImageMetadata.propTypes = {
   caption: PropTypes.string,
   /** Image author related data */
   credits: PropTypes.shape({
+    by: PropTypes.array,
+    affiliation: PropTypes.array,
+  }),
+  /** Vanity credits related data */
+  vanityCredits: PropTypes.shape({
     by: PropTypes.array,
     affiliation: PropTypes.array,
   }),

--- a/stories/ImageMetadata.stories.mdx
+++ b/stories/ImageMetadata.stories.mdx
@@ -102,3 +102,180 @@ import { ImageMetadata } from '@wpmedia/engine-theme-sdk';
         </figure>
     </Story>
 </Canvas>
+
+### **Override photographer and credits on ImageMetadata**
+
+<Canvas>
+    <Story name="Custom ImageMetadata with vanity credits">
+        <figure>
+            <Image
+                url={'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/37UMUNYNOVCEJDZW5SBKBXNMO4.jpg'}
+                alt={'Aerial view of bridge'}
+                smallWidth={158}
+                smallHeight={89}
+                mediumWidth={274}
+                mediumHeight={154}
+                largeWidth={274}
+                largeHeight={154}
+                resizedImageOptions={{
+                    '158x89': '/r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:format(jpg):quality(70)/',
+                    '274x154': '/sDwhmVtwayjjDJww8CvlWjpydGM=filters:format(jpg):quality(70)/',
+                }}
+                resizerURL={'https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer'}
+                breakpoints={{
+                    small: 420,
+                    medium: 768,
+                    large: 992,
+                }}
+            />
+          <figcaption>
+            <ImageMetadata
+                subtitle={'Custom subtitle'}
+                caption={'Custom caption'}
+                credits={{
+                    affiliation: [
+                        {
+                            name: 'Death to Stock Photo',
+                            type: 'author',
+                        },
+                    ],
+                    by: [
+                        {
+                            byline: 'John Doe (Custom credit)',
+                            name: 'John Doe',
+                            type: 'author',
+                        },
+                    ],
+                }}
+                vanityCredits={{
+                    affiliation: [
+                        {
+                            name: 'Vanity Credit',
+                            type: 'author',
+                        },
+                    ],
+                    by: [
+                        {
+                            name: 'Vanity Photographer',
+                            type: 'author',
+                        },
+                    ],
+                }}
+            />
+          </figcaption>
+        </figure>
+    </Story>
+</Canvas>
+
+
+### **Hide photographer and credits on ImageMetadata**
+
+<Canvas>
+    <Story name="Hide photographer and credits on ImageMetadata">
+        <figure>
+            <Image
+                url={'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/37UMUNYNOVCEJDZW5SBKBXNMO4.jpg'}
+                alt={'Aerial view of bridge'}
+                smallWidth={158}
+                smallHeight={89}
+                mediumWidth={274}
+                mediumHeight={154}
+                largeWidth={274}
+                largeHeight={154}
+                resizedImageOptions={{
+                    '158x89': '/r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:format(jpg):quality(70)/',
+                    '274x154': '/sDwhmVtwayjjDJww8CvlWjpydGM=filters:format(jpg):quality(70)/',
+                }}
+                resizerURL={'https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer'}
+                breakpoints={{
+                    small: 420,
+                    medium: 768,
+                    large: 992,
+                }}
+            />
+          <figcaption>
+            <ImageMetadata
+                subtitle={'Custom subtitle'}
+                caption={'Custom caption'}
+                credits={{
+                    affiliation: [
+                        {
+                            name: 'Death to Stock Photo',
+                            type: 'author',
+                        },
+                    ],
+                    by: [
+                        {
+                            byline: 'John Doe (Custom credit)',
+                            name: 'John Doe',
+                            type: 'author',
+                        },
+                    ],
+                }}
+                vanityCredits={{
+                    affiliation: [{}],
+                    by: [{}],
+                }}
+            />
+          </figcaption>
+        </figure>
+    </Story>
+</Canvas>
+
+### **Override photographer on ImageMetadata**
+
+<Canvas>
+    <Story name="Override photographer on ImageMetadata">
+        <figure>
+            <Image
+                url={'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/37UMUNYNOVCEJDZW5SBKBXNMO4.jpg'}
+                alt={'Aerial view of bridge'}
+                smallWidth={158}
+                smallHeight={89}
+                mediumWidth={274}
+                mediumHeight={154}
+                largeWidth={274}
+                largeHeight={154}
+                resizedImageOptions={{
+                    '158x89': '/r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:format(jpg):quality(70)/',
+                    '274x154': '/sDwhmVtwayjjDJww8CvlWjpydGM=filters:format(jpg):quality(70)/',
+                }}
+                resizerURL={'https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer'}
+                breakpoints={{
+                    small: 420,
+                    medium: 768,
+                    large: 992,
+                }}
+            />
+          <figcaption>
+            <ImageMetadata
+                subtitle={'Custom subtitle'}
+                caption={'Custom caption'}
+                credits={{
+                    affiliation: [
+                        {
+                            name: 'Death to Stock Photo',
+                            type: 'author',
+                        },
+                    ],
+                    by: [
+                        {
+                            byline: 'John Doe (Custom credit)',
+                            name: 'John Doe',
+                            type: 'author',
+                        },
+                    ],
+                }}
+                vanityCredits={{
+                    by: [
+                        {
+                            name: 'Vanity Photographer',
+                            type: 'author',
+                        },
+                    ],
+                }}
+            />
+          </figcaption>
+        </figure>
+    </Story>
+</Canvas>


### PR DESCRIPTION
## Description
Allow ImageMetadata ability to override credits details by using vanityCredits props.

## Jira Ticket
- [PEN-1631](https://arcpublishing.atlassian.net/browse/PEN-1631)

## Acceptance Criteria
1. If an image within the article body has vanity_credits populated with values present, those values should be used instead of the photographer and credit

2. If an image within the article body has vanity_credits but no values are present, the photographer and/or credit should not display at all on this image

3. If vanity_credits does not exist on the image, then the photographer and credit should display as they normally do (no change needed) 

4. For all of these use cases, the customer should be able to have a combination of functionality (for example, Photographer could be hidden and Credit could be a Vanity Credit; or Photographer could be unchanged and Credit could be hidden)

5. Tests and documentation are updated to cover this functionality

## Test Steps
1. Checkout feature branch
2. Run storybook: npm run storybook
3. Review the effect of change on imagemetadata section (Eg. http://localhost:6006/?path=/docs/imagemetadata--custom-image-metadata-with-vanity-credits)

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/61674931/104163507-1e14bd00-5429-11eb-852e-de6cbe280ced.png)


### After

![image](https://user-images.githubusercontent.com/61674931/104163525-27058e80-5429-11eb-8b8f-07bfa516a8c9.png)


## Dependencies or Side Effects

**This PR to update engine them sdk first, then required another PR on fusion-new-theme-blocks!**

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
