### PR TITLE
PEN-1629 Updating page titles

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -1568,6 +1568,15 @@ describe('the meta data ', () => {
       expect(wrapper.find('title').childAt(0).text()).toEqual(websiteName);
     });
 
+    it('should override title when defining title meta tag', () => {
+      const metaValue = metaValues({
+        'page-type': 'homepage',
+        title: 'This is customization title',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('title').childAt(0).text()).toEqual('This is customization title');
+    });
+
     it('should use websiteName as og:title', () => {
       const metaValue = metaValues({
         'page-type': 'homepage',

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -394,6 +394,9 @@ const MetaData: React.FC<Props> = ({
       </>
     );
   } else if (pageType === 'homepage') {
+    if (metaValue('title')) {
+      metaData.title = `${metaValue('title')}`;
+    }
     homepageMetaDataTags = (
       <>
         <meta property="og:title" content={metaData.ogTitle} />


### PR DESCRIPTION
## Description
This PR fixing the issue that user could not customize the homepage title


## Jira Ticket
- [PEN-1629](https://arcpublishing.atlassian.net/browse/PEN-1629)

## Acceptance Criteria
User should able to override homepage title

## Test Steps
1. Checkout Fusion-New_Themes master branch
2. Make sure env file configured to link engine-theme-sdk by un-comment  `ENGINE_SDK_REPO` property
3. Start fusion: `npx fusion start -f`
4. Create any page then configure meta tag
![image](https://user-images.githubusercontent.com/61674931/104580558-02f7b680-5690-11eb-8314-7afd598cdc40.png)
5. Publish the page then user should see the title that configures in meta tag


## Effect Of Changes
### Before
<img width="499" alt="Screen Shot 2021-01-14 at 17 49 16" src="https://user-images.githubusercontent.com/61674931/104581331-02135480-5691-11eb-8b32-bf7c0233e560.png">


### After
<img width="499" alt="Screen Shot 2021-01-14 at 17 44 54" src="https://user-images.githubusercontent.com/61674931/104580780-46eabb80-5690-11eb-85d7-5d6b44d2535d.png">


## Dependencies or Side Effects
N/A

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
