### PR TITLE
PEN-1603 Changed wrong size values for fallback image

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -110,8 +110,8 @@ const Image: React.FC<ImageProps> = ({
           src={url}
           alt={alt}
           // for fallback width and height
-          width={smallWidth}
-          height={smallHeight}
+          width={largeWidth}
+          height={largeHeight}
         />
       </StyledPicture>
     );


### PR DESCRIPTION
## Description
When top table list medium stories display the fallback image on the large breakpoint, the image is not as big as the rest of the images in the list. See screenshot:

## Jira Ticket
- [PEN-1643](https://arcpublishing.atlassian.net/browse/PEN-1643)

## Acceptance Criteria
The fallback image displays as the same size as other images in the medium top table list section across all breakpoints

## Test Steps
You can test with this page in corecomponents:

https://corecomponents.arcpublishing.com/pagebuilder/editor/curate/?p=pLtpiR1biLVrZr&v=vAN3yH1biLVrZr

## Effect Of Changes
### Before
![image](https://user-images.githubusercontent.com/47773457/104704728-95a95b80-574b-11eb-9210-eaad2fff479a.png)


### After
![image](https://user-images.githubusercontent.com/47773457/104704460-4531fe00-574b-11eb-89cb-d0aa6877e80b.png)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
