### PR TITLE
Fix new linting issues

### DIFF
--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/camelcase */
 import React from 'react';
 import { act } from 'react-dom/test-utils';

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -23,7 +23,6 @@
  * EventEmitter.subscribe('galleryImageNext', (event) => galleryImageNext(event));
  */
 
-
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable camelcase */
 import React, { useRef, useState, useEffect } from 'react';

--- a/src/components/Gallery/setInterval.ts
+++ b/src/components/Gallery/setInterval.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 const useInterval = (callback: Function, delay?: number | null): void => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const savedCallback = useRef<Function>(() => {});
 
   useEffect(() => {

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -19,7 +19,6 @@ const GalleryButton = styled.button`
   }
 `;
 
-
 export const ControlsDiv = styled.div`
   display: flex;
   justify-content: space-between;

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -77,7 +77,6 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
   );
 };
 
-
 ImageMetadata.propTypes = {
   /** Subtitle text for the image */
   subtitle: PropTypes.string,

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/sort-comp */
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint react/destructuring-assignment: "off", no-mixed-operators: "off", max-len: "off", comma-dangle: "off", react/jsx-props-no-spreading: "off" */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 /* eslint-disable @typescript-eslint/camelcase */
 import React, { ReactElement } from 'react';
 import ReactDOMServer from 'react-dom/server';

--- a/src/components/Video/index.tsx
+++ b/src/components/Video/index.tsx
@@ -32,7 +32,6 @@ const Video: React.FC<VideoProps> = (props) => {
     }
   }, []);
 
-
   return (
     <div className="video-container">
       <div


### PR DESCRIPTION
before: 

```
Run npm run lint

> @wpmedia/engine-theme-sdk@2.8.1-canary.14 lint /home/runner/work/engine-theme-sdk/engine-theme-sdk
> eslint . --ext .ts,.js,.tsx,.jsx


/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/Gallery/index.test.tsx
Error:   303:60  error  Unexpected empty arrow function  @typescript-eslint/no-empty-function
Error:   304:59  error  Unexpected empty arrow function  @typescript-eslint/no-empty-function

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/Gallery/index.tsx
Error:   26:1  error  More than 1 blank line not allowed  no-multiple-empty-lines

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/Gallery/setInterval.ts
Error:   4:48  error  Unexpected empty arrow function  @typescript-eslint/no-empty-function

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/Gallery/styled.ts
Error:   22:1  error  More than 1 blank line not allowed  no-multiple-empty-lines

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/ImageMetadata/index.tsx
Error:   80:1  error  More than 1 blank line not allowed  no-multiple-empty-lines
Error:   88:5  error  Prop type `array` is forbidden      react/forbid-prop-types
Error:   89:5  error  Prop type `array` is forbidden      react/forbid-prop-types
Error:   93:5  error  Prop type `array` is forbidden      react/forbid-prop-types
Error:   94:5  error  Prop type `array` is forbidden      react/forbid-prop-types

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/Lightbox/lightbox-react.tsx
Error:   409:32  error  Unexpected empty arrow function 'onAfterOpen'           @typescript-eslint/no-empty-function
Error:   410:37  error  Unexpected empty arrow function 'onImageLoadError'      @typescript-eslint/no-empty-function
Error:   411:32  error  Unexpected empty arrow function 'onImageLoad'           @typescript-eslint/no-empty-function
Error:   412:38  error  Unexpected empty arrow function 'onMoveNextRequest'     @typescript-eslint/no-empty-function
Error:   413:38  error  Unexpected empty arrow function 'onMovePrevRequest'     @typescript-eslint/no-empty-function
Error:   867:5   error  handleKeyInput should be placed before getLightboxRect  react/sort-comp

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/MetaData/index.tsx
Error:   499:7  error  Prop type `array` is forbidden  react/forbid-prop-types
Error:   500:7  error  Prop type `array` is forbidden  react/forbid-prop-types
Error:   502:5  error  Prop type `array` is forbidden  react/forbid-prop-types
Error:   503:5  error  Prop type `array` is forbidden  react/forbid-prop-types

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/Video/index.tsx
Error:   35:1  error  More than 1 blank line not allowed  no-multiple-empty-lines

/home/runner/work/engine-theme-sdk/engine-theme-sdk/src/components/VideoPlayer/formatEmbedMarkup.tsx
Error:   1:1  error  Too many blank lines at the beginning of file. Max of 0 allowed  no-multiple-empty-lines

✖ 22 problems (22 errors, 0 warnings)
  5 errors and 0 warnings potentially fixable with the `--fix` option.

```


after: 

howardj@arc-20750 engine-theme-sdk % npm run lint

> @wpmedia/engine-theme-sdk@2.8.1-canary.14 lint /Users/howardj/sites/engine-theme-sdk
> eslint . --ext .ts,.js,.tsx,.jsx

