### PR TITLE
Add storybook item for transparent png files

### DIFF
--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -171,6 +171,36 @@ import { Image } from '@wpmedia/engine-theme-sdk';
   </Story>
 </Canvas>
 
+### **PNG** File
+<Canvas>
+  <Story name="Transparent png file">
+    <Image
+      url={
+        "https://s3.amazonaws.com/arc-authors/corecomponents/ddb98950-f6c6-4362-8cf0-5faf0001609a.png"
+      }
+      alt={"Rolling Dice"}
+      smallWidth={158}
+      smallHeight={89}
+      mediumWidth={158}
+      mediumHeight={89}
+      largeWidth={158}
+      largeHeight={89}
+      resizedImageOptions={{
+        "158x89":
+          "BdkyX5wvprEpd8N4tFJxP_fdLfM=filters:format(png):quality(70)/",
+      }}
+      resizerURL={"https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer"}
+      breakpoints={{
+        small: 420,
+        medium: 768,
+        large: 992,
+      }}
+      lightBoxWidth={158}
+      lightBoxHeight={89}
+    />
+  </Story>
+</Canvas>
+
 ### **Without resizer URL**
 
 <Canvas>


### PR DESCRIPTION
## Description
Added documentation output in storybook for png images for changes in theme-blocks PR - https://github.com/WPMedia/fusion-news-theme-blocks/pull/703

## Jira Ticket
- [PEN-1432](https://arcpublishing.atlassian.net/browse/PEN-1432)

## Test Steps

1. Verify the output on storybook - http://localhost:6006/?path=/docs/image--basic

## Effect Of Changes

### After

Added documentation for png output

<img width="882" alt="PEN-1432-sdk-storybook" src="https://user-images.githubusercontent.com/868127/105718209-e4f44680-5f18-11eb-9d79-939339023382.png">


## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps above are working
- [X] Confirmed there are no linter errors
- [X] Confirmed this PR has reasonable code coverage
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.
