### PR TITLE
PEN-1606:  Fallback image on social post

### DIFF
--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -321,7 +321,7 @@ describe('the gallery block', () => {
       EventEmitter.subscribe('galleryAutoplayStart', (event: GalleryEventData) => eventHandler(event, 1));
       EventEmitter.subscribe('galleryAutoplayStop', (event: GalleryEventData) => eventHandler(event, 2));
       autoBtnWrapper.simulate('click');
-      sleep(10000).then(() => {
+      sleep(5000).then(() => {
         expect(ran.length).toBe(2);
       });
     });

--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -321,7 +321,7 @@ describe('the gallery block', () => {
       EventEmitter.subscribe('galleryAutoplayStart', (event: GalleryEventData) => eventHandler(event, 1));
       EventEmitter.subscribe('galleryAutoplayStop', (event: GalleryEventData) => eventHandler(event, 2));
       autoBtnWrapper.simulate('click');
-      sleep(5000).then(() => {
+      sleep(10000).then(() => {
         expect(ran.length).toBe(2);
       });
     });

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -298,7 +298,7 @@ const ogImageTest = (pageType: string): void => {
         content.slice(url.length * -1),
       ).toEqual(url);
     });
-    it('must not add og:image if url not found', () => {
+    it('must add og:image if url not found', () => {
       const metaValue = metaValues({
         'page-type': pageType,
       });
@@ -309,7 +309,9 @@ const ogImageTest = (pageType: string): void => {
       };
 
       const wrapper = wrapperGenerator(metaValue, globalContent);
-      expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+      expect(
+        wrapper.find("meta[property='og:image']").prop('content'),
+      ).toEqual(`${websiteDomain}${fallbackImageLocal}`);
     });
   });
 };
@@ -422,7 +424,7 @@ const twitterImageTest = (pageType: string): void => {
       ).toEqual(url);
     });
 
-    it('must not add twitter:image if url not found', () => {
+    it('must add twitter:image if url not found', () => {
       const metaValue = metaValues({
         'page-type': pageType,
       });
@@ -433,7 +435,9 @@ const twitterImageTest = (pageType: string): void => {
       };
 
       const wrapper = wrapperGenerator(metaValue, globalContent);
-      expect(wrapper.find("meta[name='twitter:image']").length).toBe(0);
+      expect(
+        wrapper.find("meta[name='twitter:image']").prop('content'),
+      ).toEqual(`${websiteDomain}${fallbackImageLocal}`);
     });
   });
 };
@@ -555,8 +559,18 @@ const noGlobalContent = (pageType: string): void => {
     expect(wrapper.find("meta[name='twitter:title']").prop('content')).toBe(websiteName);
   });
 
-  it('should not have an og:image meta tag', () => {
-    expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+  it('should not have an og:image meta tag if there is not any page-type', () => {
+    if (metaValue['page-type'] === '') {
+      expect(wrapper.find("meta[property='og:image']").length).toBe(0);
+    }
+  });
+
+  it('should have an og:image meta tag if any page-type', () => {
+    if (metaValue['page-type']) {
+      expect(
+        wrapper.find("meta[property='og:image']").prop('content'),
+      ).toEqual(`${websiteDomain}${fallbackImageLocal}`);
+    }
   });
 
   it('should not have an og:image:alt meta tag', () => {

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -163,10 +163,10 @@ const MetaData: React.FC<Props> = ({
       }
       metaData.description = metaValue('description') || description || null;
       metaData.ogTitle = metaValue('og:title') || headline || websiteName;
-      metaData.ogImage = getImgURL(metaValue, 'og:image', gc, resizerURL);
+      metaData.ogImage = getImgURL(metaValue, 'og:image', gc, resizerURL) || metaData.fallbackImage;
       metaData.ogImageAlt = getImgAlt(metaValue, 'og:image:alt', gc);
       metaData.twitterTitle = metaValue('twitterTitle') || headline || websiteName;
-      metaData.twitterImage = getImgURL(metaValue, 'twitterImage', gc, resizerURL);
+      metaData.twitterImage = getImgURL(metaValue, 'twitterImage', gc, resizerURL) || metaData.fallbackImage;
 
       // Keywords could be comma delimited string or array of string or an array of objects
       if (metaValue('keywords')) {


### PR DESCRIPTION
## Description
Fallback image does not display on social posts

## Jira Ticket
- [PEN-1606](https://arcpublishing.atlassian.net/browse/PEN-1606)

## Acceptance Criteria
We expect to see our fallback image display when there is no featured media

## Test Steps
- Create a new page Test PEN-1606.
- Choose layout @wpmedia/right-rail-block/right-rail and add `page-type` metadata with `article` value.
- Share and Publish this page.
- Open the page Test PEN-1606, then view `inspect` window of this page.

## Effect Of Changes
### Before
 There is no any tag for twitter or org image.
![image](https://user-images.githubusercontent.com/12291608/105802342-876e0180-5fcd-11eb-95c4-601c5c8f975e.png)

### After
![image](https://user-images.githubusercontent.com/12291608/105803933-192b3e00-5fd1-11eb-8006-ed1c688a1100.png)

## Dependencies or Side Effects
NO

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
