### PR TITLE
PEN-1696: Article body sometimes doesn't render server-side

### DIFF
--- a/src/components/VideoPlayer/index-ssr.test.tsx
+++ b/src/components/VideoPlayer/index-ssr.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * this is for mocking node env
+ * will not have window attribute, testing ssr
+ * https://jestjs.io/docs/en/configuration.html#testenvironment-string
+ * @jest-environment node
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import VideoPlayer from './index';
+
+describe('server-side render', () => {
+  it('renders nothing when server-side', () => {
+    const testEmbed = `
+      <div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod" data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod">
+        <script src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script>
+      </div>
+    `;
+    const wrapper = shallow(
+      <VideoPlayer embedMarkup={testEmbed} id="ssr-video" />,
+    );
+    expect(wrapper.type()).toEqual(null);
+  });
+});

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -65,32 +65,40 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 }) => {
   const { playthrough = false, autoplay = false } = customFields;
   const videoRef = useRef(id);
+  const shouldRender = !!(
+    typeof window !== 'undefined'
+    && typeof document !== 'undefined'
+  );
 
   useEffect(() => {
-    if (document.getElementById(`video-${videoRef.current}`)) {
+    if (shouldRender && document.getElementById(`video-${videoRef.current}`)) {
       const powaEl = document.getElementById(`video-${videoRef.current}`).firstElementChild;
-
       if (powaEl) {
         if (window.powaBoot) window.powaBoot();
       }
     }
     // only run on mount with []
-  }, []);
+  }, [shouldRender]);
 
-  const embedHTMLWithPlayStatus = formatEmbedMarkup(
-    embedMarkup,
-    enableAutoplay || autoplay,
-    isPlaythrough || playthrough,
+  const getEmbedHTMLWithPlayStatus = (): string => (
+    formatEmbedMarkup(
+      embedMarkup,
+      enableAutoplay || autoplay,
+      isPlaythrough || playthrough,
+    )
   );
 
-  return (
+  return shouldRender ? (
     <EmbedVideoContainer>
-      <EmbedContainer markup={embedHTMLWithPlayStatus}>
-        {/* eslint-disable-next-line react/no-danger */}
-        <div id={`video-${videoRef.current}`} dangerouslySetInnerHTML={{ __html: embedHTMLWithPlayStatus }} />
+      <EmbedContainer markup={getEmbedHTMLWithPlayStatus()}>
+        <div
+          id={`video-${videoRef.current}`}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: getEmbedHTMLWithPlayStatus() }}
+        />
       </EmbedContainer>
     </EmbedVideoContainer>
-  );
+  ) : null;
 };
 
 export default VideoPlayer;


### PR DESCRIPTION
## Description
Modified <VideoPlayer/> so that it now only renders client-side (was causing article body to fail to render server-side).

## Jira Ticket
- [PEN-1696](https://arcpublishing.atlassian.net/browse/PEN-1696)

## Acceptance Criteria
Make sure that kitchen sink article (`/2019/09/17/global-kitchen-sink-article/`) renders properly server-side

## Test Steps
1. In `Fusion-News-Theme` repo, checkout `master` & `git pull`. Set repo to use `engine-theme-sdk` locally
2. In `engine-theme-sdk`, checkout `canary`, `git pull`, then `rm -rf ./node_modules && npm i && npm run build`
3. In `fusion-news-theme-blocks`, checkout `canary` & `git pull`
4. After checking out branch in `fusion-news-theme-blocks`, run `rm -rf ./node_modules && npx lerna clean && npm i && npx lerna bootstrap && cd blocks/header-nav-chain-block && npm i && cd ../..`
5. Run `npx fusion start -f -l @wpmedia/article-body-block` in `Fusion-News-Theme`
6. Open http://localhost/pf/2019/09/17/global-kitchen-sink-article/?_website=the-gazette
7. Scroll down to the video element on the page and make sure it still renders a video player client-side. Also make sure the video player still works (click play).
8. Now go to Chrome DevTools and open the command dialog (CMD+SHIFT+P) and look for the `Disable JavaScript` action. Select this to disable JavaScript.
9. Now reload the page and you should get the server-side render. Now, the article body of the page should render properly. Previously, there was a bug in the `<VideoPlayer/>` component that was causing the article body to not render at all server-side.

## Effect Of Changes
### Before
Article body was not rendering server-side when a `<VideoPlayer/>` component was rendered to the page
![image](https://user-images.githubusercontent.com/26662906/106335773-10e23580-6253-11eb-922a-05be9e1e3567.png)

### After
Article body should now be rendering properly server-side when a `<VideoPlayer/>` component is rendered to the page
![image](https://user-images.githubusercontent.com/26662906/106334044-7e8c6280-624f-11eb-9122-253f6cefd86c.png)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
