### PR TITLE
Updates to the Image documentation. Updating the ALC links

### DIFF
--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -99,7 +99,7 @@ resizedImageOptions={{
 }}
 ```
 
-For more information on how to setup resizedImageOptions, please see: [Secure Image Resizing Quickstart](https://corecomponents.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/secure-speedy-images.md?version=2.6)
+For more information on how to setup resizedImageOptions, please see: [Secure Image Resizing Quickstart](https://redirector.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/secure-speedy-images.md?version=2.6)
 
 <ArgsTable of={Image} />
 

--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -18,11 +18,11 @@ The default is 0 for all 4 options. By adjusting those values, you can force an 
 
 ## Additional general information on images and optimization:
 
-- [How To Make Your Images Load Speedy, Secure, and SEO-Friendly](https://corecomponents.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/best-practices-images.md?version=2.6)
+- [How To Make Your Images Load Speedy, Secure, and SEO-Friendly](https://redirector.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/best-practices-images.md?version=2.6)
 
 ## For a deeper understanding on Image resizing and setup:
 
-- [Secure Image Resizing Quickstart](https://corecomponents.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/secure-speedy-images.md?version=2.6)
+- [Secure Image Resizing Quickstart](https://redirector.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/secure-speedy-images.md?version=2.6)
 
 ## Use
 


### PR DESCRIPTION
## Description
Updates to the Image documentation. Updating the ALC links

## Jira Ticket
https://arcpublishing.atlassian.net/browse/PEN-1623 See Sara's last comment

## Acceptance Criteria
when linking to ALC, the domain has to be: 
https://redirector.arcpublishing.com
rather than 
https://corecomponents.arcpublishing.com
This is because each client will access ALC through their own Arc Org domain. We use the redirector domain in links, and it is set to redirect them to their own org. Can you update those URLs to have https://redirector.arcpublishing.com as the domain instead? I think there 3 links to ALC in the docs (2 at the top and 1 in the middle) 


### After
ALC domain has been changed to https://redirector.arcpublishing.com


## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ x] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ x] Confirmed relevant documentation has been updated/added.
