### PR TITLE
Themes 84 valid date format check (pt 1)

### DIFF
--- a/src/utils/isValidDateFormatString.test.ts
+++ b/src/utils/isValidDateFormatString.test.ts
@@ -9,7 +9,6 @@ describe('Date format validater', () => {
     expect(isValidDateFormatString('%dffff')).toBe(true);
   });
   it('allows a date format with many %{letter}%{letter} valid options', () => {
-    // will return '1fffff'
     expect(isValidDateFormatString('%d%d')).toBe(true);
   });
   it('disallows a date format that is null', () => {

--- a/src/utils/isValidDateFormatString.test.ts
+++ b/src/utils/isValidDateFormatString.test.ts
@@ -1,0 +1,24 @@
+import isValidDateFormatString from './isValidDateFormatString';
+
+describe('Date format validater', () => {
+  it('allows a date with valid %{letter} format', () => {
+    expect(isValidDateFormatString('%d')).toBe(true);
+  });
+  it('allows a date format with a %{letter}fff letters after', () => {
+    // will return '1fffff'
+    expect(isValidDateFormatString('%dffff')).toBe(true);
+  });
+  it('allows a date format with many %{letter}%{letter} valid options', () => {
+    // will return '1fffff'
+    expect(isValidDateFormatString('%d%d')).toBe(true);
+  });
+  it('disallows a date format that is null', () => {
+    expect(isValidDateFormatString(null)).toBe(false);
+  });
+  it('disallows a date format that is undefined', () => {
+    expect(isValidDateFormatString(undefined)).toBe(false);
+  });
+  it('does not pass a date format with only a %{number}', () => {
+    expect(isValidDateFormatString('%5')).toBe(false);
+  });
+});

--- a/src/utils/isValidDateFormatString.ts
+++ b/src/utils/isValidDateFormatString.ts
@@ -1,0 +1,21 @@
+// deferred:
+// no numbers (perhaps unnecessary if someone wants "%d %M %Y in the era of the 1st human species")
+
+// trying to guess all of the %{letter} permutations that are allowed
+// the library timezone includes all GNU date extensions plus some more
+// via https://bigeasy.github.io/timezone/#section-54
+
+// should pass:
+// '%dffff' can have anything after matching %{letter}
+function isValidDateFormatString(potentiallyDateString: unknown): boolean {
+  // is not null (returns typeof object)
+  // is a string
+  if (typeof potentiallyDateString !== 'string') {
+    return false;
+  }
+  // contains at least one % sign
+  // contains at least one %{letter}
+  return /%[a-zA-Z]/.test(potentiallyDateString);
+}
+
+export default isValidDateFormatString;

--- a/src/utils/localizeDate.ts
+++ b/src/utils/localizeDate.ts
@@ -6,7 +6,6 @@ const DATE_FORMAT_FALLBACK = '%B %d, %Y';
 
 // date comes in Thu Mar 11 2021 17:27:24 GMT-0600 (Central Standard Time)
 const localizeDate = (date,
-  // fallback not working %B NaN, %Y
   dateFormat = DATE_FORMAT_FALLBACK,
   language = 'en',
   timeZone = 'America/New_York'): string => {

--- a/src/utils/localizeDate.ts
+++ b/src/utils/localizeDate.ts
@@ -1,11 +1,22 @@
+import isValidDateFormatString from './isValidDateFormatString';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'));
 
+const DATE_FORMAT_FALLBACK = '%B %d, %Y';
+
+// date comes in Thu Mar 11 2021 17:27:24 GMT-0600 (Central Standard Time)
 const localizeDate = (date,
-  dateFormat = '%B %d, %Y',
+  // fallback not working %B NaN, %Y
+  dateFormat = DATE_FORMAT_FALLBACK,
   language = 'en',
   timeZone = 'America/New_York'): string => {
   if (!date) return '';
+
+  let validDateFormat = dateFormat;
+
+  if (!isValidDateFormatString(dateFormat)) {
+    validDateFormat = DATE_FORMAT_FALLBACK;
+  }
 
   let locale = null;
   switch (language) {
@@ -23,7 +34,7 @@ const localizeDate = (date,
   }
   // Convert to UTC date
   const utc = tz(date);
-  return tz(utc, dateFormat, locale, timeZone);
+  return tz(utc, validDateFormat, locale, timeZone);
 };
 
 export default localizeDate;

--- a/src/utils/localizeDateTime.ts
+++ b/src/utils/localizeDateTime.ts
@@ -1,11 +1,20 @@
+import isValidDateFormatString from './isValidDateFormatString';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
 
+const DATE_TIME_FORMAT_FALLBACK = '%B %d, %Y at %l:%M %P %Z';
+
 const localizeDateTime = (date,
-  dateFormat = '%B %d, %Y at %l:%M %P %Z',
+  dateFormat = DATE_TIME_FORMAT_FALLBACK,
   language = 'en',
   timeZone = 'America/New_York'): string => {
   if (!date) return '';
+
+  let validDateFormat = dateFormat;
+
+  if (!isValidDateFormatString(dateFormat)) {
+    validDateFormat = DATE_TIME_FORMAT_FALLBACK;
+  }
 
   let locale = null;
   switch (language) {
@@ -35,7 +44,7 @@ const localizeDateTime = (date,
   }
   // Convert to UTC date
   const utc = tz(date);
-  return tz(utc, dateFormat, locale, timeZone);
+  return tz(utc, validDateFormat, locale, timeZone);
 };
 
 export default localizeDateTime;


### PR DESCRIPTION
- base fix for ticket linked
- fixing previous ticket with regard to regions https://github.com/WPMedia/engine-theme-sdk/pull/255

## Description
Invalid date format in timezone library shows posix time 

## Jira Ticket
https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=838&projectKey=THEMES&modal=detail&selectedIssue=THEMES-84&assignee=5e387d6a1b1d910e5dfd7a9b

## Acceptance Criteria

- Pass in valid %{letter} format via tests 
- Falls back to defaults if invalid format 

deferred: 
- invalid timezone reverts back to utc with the library (as desired)
![image](https://user-images.githubusercontent.com/5950956/110970886-cf4bac80-831f-11eb-9640-7bf3826a0133.png)

## Test Steps
- Look at tests

test live
- Could link engine theme sdk and pass in null or 'bad string' invalid formats via news-theme-blocks or manually linking blocks 

blocks.json: 

```json
      "the-gazette": {
        "siteProperties": {
          "websiteName": "The Gazette",
          "copyrightText": "Copyright The Gazette 2-19-2021",
          "rssUrl": "washingtonpost",
          "dateLocalization": {
            "language": null,
            "timeZone": null,
            "dateTimeFormat": null,
            "dateFormat": null
          },
```
- or manually link the blocks and engine theme sdk hard-code the tests 
- `ENGINE_SDK_REPO=/Users/{your path}/engine-theme-sdk`
- `npx fusion start -f -l @wpmedia/masthead-block`

```jsx
  const {
    dateLocalization: { language, timeZone, dateFormat } = { language: 'en', timeZone: 'GMT', dateFormat: 'LLLL d, yyyy' },
  } = getProperties(arcSite);

  const badDateFormat = null;
  const displayDate = localizeDate(new Date(), badDateFormat, language, timeZone);
```
- 

## Effect Of Changes
### Before
- invalid date format returns posix non-human readable

### After
- falls back to default specified in the engine theme sdk 

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- none

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
