### PR TITLE
THEMES-119: perf localization 

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "react-swipeable": "^5.5.0",
     "styled-components": "^4.4.1",
     "thumbor-lite": "^0.1.6",
-    "timezone": "^1.0.23"
+    "timezone": "1.0.23"
   }
 }

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -14,7 +14,7 @@ it('returns us east expected output with at', () => {
 // without require timezones
 // eslint-disable-next-line max-len
 // const tz = require('timezone')(require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
-it('returns American english language and utc date for timezone not found est', () => {
+it('returns American english language and utc date for timezone not found', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',
@@ -24,7 +24,9 @@ it('returns American english language and utc date for timezone not found est', 
       // india standard time
       'Asia/Kolkata',
     ),
-  ).toMatchInlineSnapshot('"January 01, 2000  8:00 pm EST"');
+  ).toMatchInlineSnapshot(
+    '"January 02, 2000  1:00 am UTC"',
+  );
 });
 
 it('returns seoul for locale ko', () => {
@@ -35,5 +37,5 @@ it('returns seoul for locale ko', () => {
       'ko',
       'Asia/Seoul',
     ),
-  ).toMatchInlineSnapshot('"January 02, 2000 10:00 am KST"');
+  ).toMatchInlineSnapshot('"1월 02, 2000 10:00 오전 KST"');
 });

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -3,10 +3,31 @@ import localizeDateHelper from './localizeDateHelper';
 it('returns us east expected output with at', () => {
   expect(
     localizeDateHelper(
-      '2000-01-02',
+      '2000-01-02 01:00',
       '%B %d, %Y at %l:%M %P %Z',
       'en',
       'America/New_York',
     ),
-  ).toMatchInlineSnapshot('"January 01, 2000 at  7:00 pm EST"');
+  ).toMatchInlineSnapshot(
+    '"January 01, 2000 at  8:00 pm EST"',
+  );
+});
+
+it('returns time zone for unspecified locale but falls back to english language for month names if not matched', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02 01:00',
+      '%B %d, %Y at %l:%M %P %Z',
+      // hindi
+      // to match language should be "जनवरी 02, 2000 at  6:30 पूर्वाह्न IST"
+      // Snapshot: "January 02, 2000 at  6:30 am IST"
+      // Received: "जनवरी 02, 2000 at  6:30 पूर्वाह्न IST"
+      'hi_IN',
+      // india has half-hour timezone +05:30
+      // india standard time
+      'Asia/Kolkata',
+    ),
+  ).toMatchInlineSnapshot(
+    '"January 02, 2000 at  6:30 am IST"',
+  );
 });

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -11,22 +11,29 @@ it('returns us east expected output with at', () => {
   ).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
 });
 
-it('returns American english language for not found locale, but uses correct time zone passed in', () => {
+// without require timezones
+// eslint-disable-next-line max-len
+// const tz = require('timezone')(require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
+it('returns American english language and utc date for timezone not found est', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',
       '%B %d, %Y %l:%M %P %Z',
-      // hindi
-      // to match language should be "जनवरी 02, 2000 6:30 पूर्वाह्न IST"
-      // Snapshot: "January 02, 2000 6:30 am IST"
-      // Received: "जनवरी 02, 2000 6:30 पूर्वाह्न IST"
-      // todo: should be able to pass in any language and country locale
       'hi_IN',
       // india has half-hour timezone +05:30
       // india standard time
       'Asia/Kolkata',
     ),
-  ).toMatchInlineSnapshot(
-    '"January 02, 2000  6:30 am IST"',
-  );
+  ).toMatchInlineSnapshot('"January 01, 2000  8:00 pm EST"');
+});
+
+it('returns seoul for locale ko', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02 01:00',
+      '%B %d, %Y %l:%M %P %Z',
+      'ko',
+      'Asia/Seoul',
+    ),
+  ).toMatchInlineSnapshot('"January 02, 2000 10:00 am KST"');
 });

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -11,7 +11,7 @@ it('returns us east expected output with at', () => {
   ).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
 });
 
-it('returns time zone for unspecified locale but falls back to english language for month names if not matched', () => {
+it('returns American english language for not found locale, but uses correct time zone passed in', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -11,9 +11,6 @@ it('returns us east expected output with at', () => {
   ).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
 });
 
-// without require timezones
-// eslint-disable-next-line max-len
-// const tz = require('timezone')(require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
 it('returns American english language and utc date for timezone not found', () => {
   expect(
     localizeDateHelper(

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -8,26 +8,25 @@ it('returns us east expected output with at', () => {
       'en',
       'America/New_York',
     ),
-  ).toMatchInlineSnapshot(
-    '"January 01, 2000 at  8:00 pm EST"',
-  );
+  ).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
 });
 
 it('returns time zone for unspecified locale but falls back to english language for month names if not matched', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',
-      '%B %d, %Y at %l:%M %P %Z',
+      '%B %d, %Y %l:%M %P %Z',
       // hindi
       // to match language should be "जनवरी 02, 2000 at  6:30 पूर्वाह्न IST"
-      // Snapshot: "January 02, 2000 at  6:30 am IST"
-      // Received: "जनवरी 02, 2000 at  6:30 पूर्वाह्न IST"
+      // Snapshot: "January 02, 2000 6:30 am IST"
+      // Received: "जनवरी 02, 2000 6:30 पूर्वाह्न IST"
+      // todo: should be able to pass in any language and country locale
       'hi_IN',
       // india has half-hour timezone +05:30
       // india standard time
       'Asia/Kolkata',
     ),
   ).toMatchInlineSnapshot(
-    '"January 02, 2000 at  6:30 am IST"',
+    '"January 02, 2000  6:30 am IST"',
   );
 });

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -21,12 +21,10 @@ it('returns American english language and utc date for timezone not found', () =
       // india standard time
       'Asia/Kolkata',
     ),
-  ).toMatchInlineSnapshot(
-    '"January 02, 2000  1:00 am UTC"',
-  );
+  ).toMatchInlineSnapshot('"January 02, 2000  1:00 am UTC"');
 });
 
-it('returns seoul for locale ko', () => {
+it('returns correct Korean language for locale ko but falls back to UTC', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',
@@ -34,5 +32,27 @@ it('returns seoul for locale ko', () => {
       'ko',
       'Asia/Seoul',
     ),
-  ).toMatchInlineSnapshot('"1월 02, 2000 10:00 오전 KST"');
+  ).toMatchInlineSnapshot('"1월 02, 2000  1:00 오전 UTC"');
+});
+
+it('supports language and timezone for Kiwis speaking Spain Spanish', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02 01:00',
+      '%B %d, %Y %l:%M %P %Z',
+      'es',
+      'Pacific/Auckland',
+    ),
+  ).toMatchInlineSnapshot('"enero 02, 2000  2:00  NZDT"');
+});
+
+it('Supports french-speakers in Paris', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02 01:00',
+      '%B %d, %Y %l:%M %P %Z',
+      'fr',
+      'Europe/Paris',
+    ),
+  ).toMatchInlineSnapshot('"janvier 02, 2000  2:00  CET"');
 });

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -17,7 +17,7 @@ it('returns American english language for not found locale, but uses correct tim
       '2000-01-02 01:00',
       '%B %d, %Y %l:%M %P %Z',
       // hindi
-      // to match language should be "जनवरी 02, 2000 at  6:30 पूर्वाह्न IST"
+      // to match language should be "जनवरी 02, 2000 6:30 पूर्वाह्न IST"
       // Snapshot: "January 02, 2000 6:30 am IST"
       // Received: "जनवरी 02, 2000 6:30 पूर्वाह्न IST"
       // todo: should be able to pass in any language and country locale

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -1,5 +1,6 @@
 import localizeDateHelper from './localizeDateHelper';
 
+// supported locale and timezone
 it('returns us east expected output with at', () => {
   expect(
     localizeDateHelper(
@@ -11,6 +12,7 @@ it('returns us east expected output with at', () => {
   ).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
 });
 
+// unsupported locale and timezone
 it('returns American english language and utc date for timezone not found', () => {
   expect(
     localizeDateHelper(
@@ -24,6 +26,8 @@ it('returns American english language and utc date for timezone not found', () =
   ).toMatchInlineSnapshot('"January 02, 2000  1:00 am UTC"');
 });
 
+// supported locale
+// unsupported timezone
 it('returns correct Korean language for locale ko but falls back to UTC', () => {
   expect(
     localizeDateHelper(
@@ -35,24 +39,29 @@ it('returns correct Korean language for locale ko but falls back to UTC', () => 
   ).toMatchInlineSnapshot('"1월 02, 2000  1:00 오전 UTC"');
 });
 
-it('supports language and timezone for Kiwis speaking Spain Spanish', () => {
+// supported timezones
+// supported language en to show am/pm
+// Pacific/Auckland GMT+13
+it('supports Auckland timezone', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',
       '%B %d, %Y %l:%M %P %Z',
-      'es',
+      'en',
       'Pacific/Auckland',
     ),
-  ).toMatchInlineSnapshot('"enero 02, 2000  2:00  NZDT"');
+  ).toMatchInlineSnapshot('"January 02, 2000  2:00 pm NZDT"');
 });
 
-it('Supports french-speakers in Paris', () => {
+// supported timezone
+// paris (GMT+1)
+it('supports Paris timezone', () => {
   expect(
     localizeDateHelper(
       '2000-01-02 01:00',
       '%B %d, %Y %l:%M %P %Z',
-      'fr',
+      'en',
       'Europe/Paris',
     ),
-  ).toMatchInlineSnapshot('"janvier 02, 2000  2:00  CET"');
+  ).toMatchInlineSnapshot('"January 02, 2000  2:00 am CET"');
 });

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -1,0 +1,12 @@
+import localizeDateHelper from './localizeDateHelper';
+
+it('returns us east expected output with at', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02',
+      '%B %d, %Y at %l:%M %P %Z',
+      'en',
+      'America/New_York',
+    ),
+  ).toMatchInlineSnapshot('"January 01, 2000 at  7:00 pm EST"');
+});

--- a/src/utils/localizeDate.ts
+++ b/src/utils/localizeDate.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'));
+import localizeDateHelper from './localizeDateHelper';
 
 const localizeDate = (date,
   dateFormat = '%B %d, %Y',
@@ -7,23 +6,12 @@ const localizeDate = (date,
   timeZone = 'America/New_York'): string => {
   if (!date) return '';
 
-  let locale = null;
-  switch (language) {
-    case 'sv':
-      locale = 'sv_SE';
-      break;
-    case 'fr':
-      locale = 'fr_FR';
-      break;
-    case 'no':
-      locale = 'nb_NO';
-      break;
-    default:
-      locale = 'en_US';
-  }
-  // Convert to UTC date
-  const utc = tz(date);
-  return tz(utc, dateFormat, locale, timeZone);
+  return localizeDateHelper(
+    date,
+    dateFormat,
+    language,
+    timeZone,
+  );
 };
 
 export default localizeDate;

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -13,13 +13,22 @@ const tz = require('timezone')(
 
   // supported locales
   // locale is related to language and place (eg, Spanish and Mexico)
+  // korean
   require('timezone/ko_KR'),
+  // japanese
   require('timezone/ja_JP'),
+  // Spain Spanish
   require('timezone/es_ES'),
+  // Swedish
   require('timezone/sv_SE'),
+  // American English
   require('timezone/en_US'),
+  // german
   require('timezone/de_DE'),
+  // french
   require('timezone/fr_FR'),
+  // norwegian
+  require('timezone/nb_NO'),
 );
 
 function localizeDateHelper(

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -1,7 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
-
+/* eslint-disable @typescript-eslint/no-var-requires,global-require */
 // tz docs https://bigeasy.github.io/timezone/
+import tz from 'timezone';
+
 function localizeDateHelper(
   date: string,
   targetDateFormat: string,
@@ -9,13 +9,6 @@ function localizeDateHelper(
   timeZone: string,
 ): string {
   let locale = null;
-  // locale is the language, like English has January
-  // language list can be found here https://github.com/bigeasy/timezone/tree/master/src/locales
-  // all languages are being imported
-  // but catching ones not matched to english or specified one to language
-  // country and language can affect translations as well
-  // eg, spain spanish and mexican spanish can be different
-  // todo: language should be able to pass in anything
   switch (language) {
     case 'sv':
       locale = 'sv_SE';
@@ -42,11 +35,46 @@ function localizeDateHelper(
     default:
       locale = 'en_US';
   }
+
   // Convert to UTC date
   const utc = tz(date);
 
+  if (locale === 'en_US') {
+    const NYC = tz(require('timezone/America/New_York'));
+    return NYC(utc, 'America/New_York', targetDateFormat);
+  }
+
+  if (locale === 'ko_KR') {
+    const KOREA = tz(require('timezone/Asia/Seoul'));
+    return KOREA(utc, 'Asia/Seoul', targetDateFormat);
+  }
+
+  if (locale === 'ja_JP') {
+    const JAPAN = tz(require('timezone/Asia/Tokyo'));
+    return JAPAN(utc, 'Asia/Tokyo', targetDateFormat);
+  }
+
+  if (locale === 'es_ES') {
+    const MADRID = tz(require('timezone/Europe/Madrid'));
+    return MADRID(utc, 'Europe/Madrid', targetDateFormat);
+  }
+
+  if (locale === 'de_DE') {
+    const BUSINGEN = tz(require('timezone/Europe/Busingen'));
+    return BUSINGEN(utc, 'Europe/Busingen', targetDateFormat);
+  }
+
+  if (locale === 'fr_FR') {
+    const PARIS = tz(require('timezone/Europe/Paris'));
+    return PARIS(utc, 'Europe/Paris', targetDateFormat);
+  }
+
+  if (locale === 'sv_SE') {
+    const STOCKHOLM = tz(require('timezone/Europe/Stockholm'));
+    return STOCKHOLM(utc, 'timezone/Stockholm', targetDateFormat);
+  }
+
   // timezone is the TZ database name https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  // all timezones currently work
   return tz(utc, targetDateFormat, locale, timeZone);
 }
 

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -1,0 +1,43 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
+
+// tz docs https://bigeasy.github.io/timezone/
+function localizeDateHelper(
+  date: string,
+  targetDateFormat: string,
+  language: string,
+  timeZone: string,
+): string {
+  let locale = null;
+  switch (language) {
+    case 'sv':
+      locale = 'sv_SE';
+      break;
+    case 'fr':
+      locale = 'fr_FR';
+      break;
+    case 'no':
+      locale = 'nb_NO';
+      break;
+    case 'de':
+      locale = 'de_DE';
+      break;
+    case 'es':
+      locale = 'es_ES';
+      break;
+    case 'ja':
+      locale = 'ja_JP';
+      break;
+    case 'ko':
+      locale = 'ko_KR';
+      break;
+    case 'en':
+    default:
+      locale = 'en_US';
+  }
+  // Convert to UTC date
+  const utc = tz(date);
+  return tz(utc, targetDateFormat, locale, timeZone);
+}
+
+export default localizeDateHelper;

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -1,6 +1,26 @@
 /* eslint-disable @typescript-eslint/no-var-requires,global-require */
 // tz docs https://bigeasy.github.io/timezone/
-import tz from 'timezone';
+const tz = require('timezone')(
+  // supported timezones
+  // timezone is the quirks of the area time-wise (eg daylight savings) and timezone
+  require('timezone/Asia/Seoul'),
+  require('timezone/Asia/Tokyo'),
+  require('timezone/Europe/Madrid'),
+  require('timezone/Europe/Busingen'),
+  require('timezone/Europe/Paris'),
+  require('timezone/Europe/Stockholm'),
+  require('timezone/America/New_York'),
+
+  // supported locales
+  // locale is related to language and place (eg, Spanish and Mexico)
+  require('timezone/ko_KR'),
+  require('timezone/ja_JP'),
+  require('timezone/es_ES'),
+  require('timezone/sv_SE'),
+  require('timezone/en_US'),
+  require('timezone/de_DE'),
+  require('timezone/fr_FR'),
+);
 
 function localizeDateHelper(
   date: string,
@@ -37,53 +57,10 @@ function localizeDateHelper(
   }
 
   // Convert to UTC date
+  // utc time is not region-specific
   const utc = tz(date);
 
-  // performance improvement via https://github.com/bigeasy/timezone/issues/292#issuecomment-354597725
-
-  // 1. match locale.
-  // locale is related to language and place (eg, Spanish and Mexico)
-  // 2. require target locale and timezone
-  // timezone is the quirks of the area time-wise (eg daylight savings)
-  // 3. use the function along with utc time and target date format
-  // utc time is not region-specific
-  // targetDateFormat is like "%d %m" for day month, formatting
-
-  if (locale === 'ko_KR') {
-    const SEOUL = tz(require('timezone/Asia/Seoul'), require('timezone/ko_KR'));
-    return SEOUL(utc, 'Asia/Seoul', targetDateFormat);
-  }
-
-  if (locale === 'ja_JP') {
-    const TOKYO = tz(require('timezone/Asia/Tokyo'), require('timezone/ja_JP'));
-    return TOKYO(utc, 'Asia/Tokyo', targetDateFormat);
-  }
-
-  if (locale === 'es_ES') {
-    const MADRID = tz(require('timezone/Europe/Madrid'), require('timezone/es_ES'));
-    return MADRID(utc, locale, 'Europe/Madrid', targetDateFormat);
-  }
-
-  if (locale === 'de_DE') {
-    const BUSINGEN = tz(require('timezone/Europe/Busingen'), require('timezone/de_DE'));
-    return BUSINGEN(utc, locale, 'Europe/Busingen', targetDateFormat);
-  }
-
-  if (locale === 'fr_FR') {
-    const PARIS = tz(require('timezone/Europe/Paris'), require('timezone/fr_FR'));
-    return PARIS(utc, locale, 'Europe/Paris', targetDateFormat);
-  }
-
-  if (locale === 'sv_SE') {
-    const STOCKHOLM = tz(require('timezone/Europe/Stockholm'), require('timezone/sv_SE'));
-    return STOCKHOLM(utc, locale, 'timezone/Stockholm', targetDateFormat);
-  }
-
-  // default case
-  // if (locale === 'en_US') {
-  const NYC = tz(require('timezone/America/New_York'), require('timezone/en_US'));
-  return NYC(utc, locale, 'America/New_York', targetDateFormat);
-  // }
+  return tz(utc, locale, timeZone, targetDateFormat);
 }
 
 export default localizeDateHelper;

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -10,6 +10,7 @@ const tz = require('timezone')(
   require('timezone/Europe/Paris'),
   require('timezone/Europe/Stockholm'),
   require('timezone/America/New_York'),
+  require('timezone/Europe/Oslo'),
 
   // supported locales
   // locale is related to language and place (eg, Spanish and Mexico)

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires,global-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
 // tz docs https://bigeasy.github.io/timezone/
 const tz = require('timezone')(
   // supported timezones

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -50,7 +50,7 @@ function localizeDateHelper(
   // targetDateFormat is like "%d %m" for day month, formatting
 
   if (locale === 'ko_KR') {
-    const SEOUL = tz(require('timezone/Asia/Seoul'), require('ko_KR'));
+    const SEOUL = tz(require('timezone/Asia/Seoul'), require('timezone/ko_KR'));
     return SEOUL(utc, 'Asia/Seoul', targetDateFormat);
   }
 

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -39,43 +39,51 @@ function localizeDateHelper(
   // Convert to UTC date
   const utc = tz(date);
 
-  if (locale === 'en_US') {
-    const NYC = tz(require('timezone/America/New_York'));
-    return NYC(utc, 'America/New_York', targetDateFormat);
-  }
+  // performance improvement via https://github.com/bigeasy/timezone/issues/292#issuecomment-354597725
+
+  // 1. match locale.
+  // locale is related to language and place (eg, Spanish and Mexico)
+  // 2. require target locale and timezone
+  // timezone is the quirks of the area time-wise (eg daylight savings)
+  // 3. use the function along with utc time and target date format
+  // utc time is not region-specific
+  // targetDateFormat is like "%d %m" for day month, formatting
 
   if (locale === 'ko_KR') {
-    const KOREA = tz(require('timezone/Asia/Seoul'));
-    return KOREA(utc, 'Asia/Seoul', targetDateFormat);
+    const SEOUL = tz(require('timezone/Asia/Seoul'), require('ko_KR'));
+    return SEOUL(utc, 'Asia/Seoul', targetDateFormat);
   }
 
   if (locale === 'ja_JP') {
-    const JAPAN = tz(require('timezone/Asia/Tokyo'));
-    return JAPAN(utc, 'Asia/Tokyo', targetDateFormat);
+    const TOKYO = tz(require('timezone/Asia/Tokyo'), require('timezone/ja_JP'));
+    return TOKYO(utc, 'Asia/Tokyo', targetDateFormat);
   }
 
   if (locale === 'es_ES') {
-    const MADRID = tz(require('timezone/Europe/Madrid'));
-    return MADRID(utc, 'Europe/Madrid', targetDateFormat);
+    const MADRID = tz(require('timezone/Europe/Madrid'), require('timezone/es_ES'));
+    return MADRID(utc, locale, 'Europe/Madrid', targetDateFormat);
   }
 
   if (locale === 'de_DE') {
-    const BUSINGEN = tz(require('timezone/Europe/Busingen'));
-    return BUSINGEN(utc, 'Europe/Busingen', targetDateFormat);
+    const BUSINGEN = tz(require('timezone/Europe/Busingen'), require('timezone/de_DE'));
+    return BUSINGEN(utc, locale, 'Europe/Busingen', targetDateFormat);
   }
 
   if (locale === 'fr_FR') {
-    const PARIS = tz(require('timezone/Europe/Paris'));
-    return PARIS(utc, 'Europe/Paris', targetDateFormat);
+    const PARIS = tz(require('timezone/Europe/Paris'), require('timezone/fr_FR'));
+    return PARIS(utc, locale, 'Europe/Paris', targetDateFormat);
   }
 
   if (locale === 'sv_SE') {
-    const STOCKHOLM = tz(require('timezone/Europe/Stockholm'));
-    return STOCKHOLM(utc, 'timezone/Stockholm', targetDateFormat);
+    const STOCKHOLM = tz(require('timezone/Europe/Stockholm'), require('timezone/sv_SE'));
+    return STOCKHOLM(utc, locale, 'timezone/Stockholm', targetDateFormat);
   }
 
-  // timezone is the TZ database name https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  return tz(utc, targetDateFormat, locale, timeZone);
+  // default case
+  // if (locale === 'en_US') {
+  const NYC = tz(require('timezone/America/New_York'), require('timezone/en_US'));
+  return NYC(utc, locale, 'America/New_York', targetDateFormat);
+  // }
 }
 
 export default localizeDateHelper;

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -10,12 +10,12 @@ const tz = require('timezone')(
   // require('timezone/Asia/Tokyo'),
 
   // Europe
-  // client not actively using
-  // require('timezone/Europe/Busingen'),
-  // require('timezone/Europe/Madrid'),
   require('timezone/Europe/Paris'),
   require('timezone/Europe/Oslo'),
   require('timezone/Europe/Stockholm'),
+  // client not actively using
+  // require('timezone/Europe/Busingen'),
+  // require('timezone/Europe/Madrid'),
 
   // Americas
   require('timezone/America/New_York'),

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -3,14 +3,28 @@
 const tz = require('timezone')(
   // supported timezones
   // timezone is the quirks of the area time-wise (eg daylight savings) and timezone
-  require('timezone/Asia/Seoul'),
-  require('timezone/Asia/Tokyo'),
-  require('timezone/Europe/Madrid'),
-  require('timezone/Europe/Busingen'),
+
+  // Asia
+  // client not actively using
+  // require('timezone/Asia/Seoul'),
+  // require('timezone/Asia/Tokyo'),
+
+  // Europe
+  // client not actively using
+  // require('timezone/Europe/Busingen'),
+  // require('timezone/Europe/Madrid'),
   require('timezone/Europe/Paris'),
-  require('timezone/Europe/Stockholm'),
-  require('timezone/America/New_York'),
   require('timezone/Europe/Oslo'),
+  require('timezone/Europe/Stockholm'),
+
+  // Americas
+  require('timezone/America/New_York'),
+  require('timezone/America/Chicago'),
+  require('timezone/America/Los_Angeles'),
+  require('timezone/America/Mexico_City'),
+
+  // Pacific
+  require('timezone/Pacific/Auckland'),
 
   // supported locales
   // locale is related to language and place (eg, Spanish and Mexico)

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -9,6 +9,13 @@ function localizeDateHelper(
   timeZone: string,
 ): string {
   let locale = null;
+  // locale is the language, like English has January
+  // language list can be found here https://github.com/bigeasy/timezone/tree/master/src/locales
+  // all languages are being imported
+  // but catching ones not matched to english or specified one to language
+  // country and language can affect translations as well
+  // eg, spain spanish and mexican spanish can be different
+  // todo: language should be able to pass in anything
   switch (language) {
     case 'sv':
       locale = 'sv_SE';
@@ -37,6 +44,9 @@ function localizeDateHelper(
   }
   // Convert to UTC date
   const utc = tz(date);
+
+  // timezone is the TZ database name https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  // all timezones currently work
   return tz(utc, targetDateFormat, locale, timeZone);
 }
 

--- a/src/utils/localizeDateTime.ts
+++ b/src/utils/localizeDateTime.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const tz = require('timezone')(require('timezone/zones'), require('timezone/en_US.js'), require('timezone/sv_SE.js'), require('timezone/fr_FR.js'), require('timezone/nb_NO.js'), require('timezone/de_DE'), require('timezone/es_ES'), require('timezone/ja_JP'), require('timezone/ko_KR'));
+import localizeDateHelper from './localizeDateHelper';
 
 const localizeDateTime = (date,
   dateFormat = '%B %d, %Y at %l:%M %P %Z',
@@ -7,35 +6,13 @@ const localizeDateTime = (date,
   timeZone = 'America/New_York'): string => {
   if (!date) return '';
 
-  let locale = null;
-  switch (language) {
-    case 'sv':
-      locale = 'sv_SE';
-      break;
-    case 'fr':
-      locale = 'fr_FR';
-      break;
-    case 'no':
-      locale = 'nb_NO';
-      break;
-    case 'de':
-      locale = 'de_DE';
-      break;
-    case 'es':
-      locale = 'es_ES';
-      break;
-    case 'ja':
-      locale = 'ja_JP';
-      break;
-    case 'ko':
-      locale = 'ko_KR';
-      break;
-    default:
-      locale = 'en_US';
-  }
-  // Convert to UTC date
-  const utc = tz(date);
-  return tz(utc, dateFormat, locale, timeZone);
+  return localizeDateHelper(
+    date,
+    // default includes time (see dateTimeFormat property)
+    dateFormat,
+    language,
+    timeZone,
+  );
 };
 
 export default localizeDateTime;


### PR DESCRIPTION
https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=838&projectKey=THEMES&modal=detail&selectedIssue=THEMES-119&assignee=5e387d6a1b1d910e5dfd7a9b


- maintains same behavior showing locale and timezone of supported timezones specified. see test instructions for changing sites via https://github.com/WPMedia/engine-theme-sdk/pull/255
- we may need to do some messaging on this to give clients more flexibility for timezones
- @badmintonkid mentioned using postinstall to target locales and timezones as needed https://github.com/wapopartners/LeParisien-PageBuilder-Fusion-Features/blob/master/scripts/postinstall.js
- related to Eric's comment here about timezone being about 50% of the bundle https://arcpublishing.atlassian.net/browse/TMEDIA-13?focusedCommentId=525572&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel
- to test, use bundle analyzer https://redirector.arcpublishing.com/alc/arc-products/pagebuilder/fusion/documentation/recipes/webpack-stats.md?version=2.7

before 

![Screen Shot 2021-03-12 at 15 22 46](https://user-images.githubusercontent.com/5950956/111003780-611dde80-834d-11eb-9a30-6ae336a69886.png)

<img width="430" alt="Screen Shot 2021-03-12 at 16 14 15" src="https://user-images.githubusercontent.com/5950956/111004124-033dc680-834e-11eb-8d4a-0346cbfbcb0c.png">

after: 

![Screen Shot 2021-03-12 at 15 46 00](https://user-images.githubusercontent.com/5950956/111003718-477c9700-834d-11eb-8cf2-3c5eac0820d3.png)

![Screen Shot 2021-03-12 at 15 45 55](https://user-images.githubusercontent.com/5950956/111003744-53685900-834d-11eb-8277-859bc59b906e.png)

