### PR TITLE
ci: Ignore dependabot branches for storybook

### DIFF
--- a/.github/workflows/storybook-validate.yml
+++ b/.github/workflows/storybook-validate.yml
@@ -3,6 +3,8 @@ name: Deploy storybook
 on:
   pull_request:
     types: [synchronize, opened]
+    branches-ignore:
+      - "dependabot/*"
 
 jobs:
   chromatic_publish_validate:


### PR DESCRIPTION
- Having an issue where project storybook token not found for dependabot prs 