### PR TITLE
Themes 107 lead art lightbox overlay

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -12,6 +12,7 @@
           "fusion:environment": "./.storybook/environment.json"
         }
       }
-    ]
+    ],
+    "@babel/plugin-proposal-optional-chaining"
   ]
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,6 +7,7 @@ module.exports = (api) => {
         loose: true,
       },
     ],
+    '@babel/plugin-proposal-optional-chaining',
   ];
 
   if (api.env('commonjs') || api.env('test')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -623,14 +623,22 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
-      "integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-proposal-private-methods": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/core": "^7.10.3",
     "@babel/plugin-proposal-class-properties": "^7.12.13",
     "@babel/plugin-proposal-decorators": "^7.12.12",
+    "@babel/plugin-proposal-optional-chaining": "^7.13.12",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@babel/preset-react": "^7.10.1",
     "@babel/preset-typescript": "^7.10.1",

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -240,6 +240,8 @@ const Gallery: React.FC<GalleryProps> = ({
     }
   };
 
+  // see error handling in lightbox for empty string
+  // empty string means that the image is invalid
   const lightboxHandler = (pageNo, operation): string => {
     const nodeList = galleryRef.current.querySelectorAll('img');
     if (nodeList && nodeList.length) {
@@ -257,15 +259,32 @@ const Gallery: React.FC<GalleryProps> = ({
 
     // querySelectorAll looks like not rendered next image
     // and we getting empty data for lightBox
-    if (galleryElements[pageNo]) {
+
+    // all lightbox images are that size 1600 wide, native whatever height (0)
+    const targetLightboxDimensions = `${1600}x${0}`;
+
+    const lightboxHashString = galleryElements[pageNo]?.resized_params[targetLightboxDimensions];
+
+    // should be a non-empty string
+    if (lightboxHashString) {
       const galleryElement = galleryElements[pageNo];
+
+      // if invalid image then we wouldn't want to try to resize at all
       const imageSourceWithoutProtocol = galleryElement.url.replace('https://', '');
-      const imageSrc = buildThumborURL(galleryElement.resized_params[`${1600}x${0}`], `${1600}x${0}`,
+
+      // reconstructs valid image url just for target dimensions
+      const imageSrc = buildThumborURL(
+        lightboxHashString,
+        targetLightboxDimensions,
         imageSourceWithoutProtocol,
-        resizerURL);
+        resizerURL,
+      );
       return imageSrc;
     }
 
+    // will return an empty string if no image found
+    // if empty string, then lightbox will show error string
+    // shows "Image not found" by default, see Lightbox
     return '';
   };
 

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1708,9 +1708,17 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
         );
       };
 
+      // todo: this global variable scope displayItems should be handled with utils and helper
       const addItem = (srcType, imageClass, baseStyle = {}): void => {
-        const DisplayItem = this.props[srcType];
-        if (!DisplayItem) {
+        const targetImage = this.props[srcType];
+        // if falsy or invalid item, then don't show image potentially
+        // or maybe just let the image shown and then have the broken image icon
+        // we can never know if a string is actually a valid image
+
+        // if empty string, then image not found
+        // see lightboxHandler
+        if (targetImage === '') {
+          // pushing to global scoped display items
           displayItems.push(
             <LightboxImage
               as="div"
@@ -1721,15 +1729,16 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
               <ErrorContainer className="errorContainer">{this.props.imageLoadErrorMessage}</ErrorContainer>
             </LightboxImage>,
           );
-
-          return;
-        }
-
-        if (typeof DisplayItem === 'string') {
+        } else if (typeof targetImage === 'string') {
+          // addImage is a helper component that adds an image to displayItems
           addImage(srcType, imageClass, baseStyle);
-        }
-        if (isReact.component(DisplayItem) || isReact.element(DisplayItem)) {
+        } else if (targetImage === null) {
+          // then there's no prev image or next image, like for a lone lightbox
+          // will not show error for no image found
+        } else if (isReact.component(targetImage) || isReact.element(targetImage)) {
           addComponent(srcType, imageClass, baseStyle);
+        } else {
+          throw new Error('Could not recognize lightbox image');
         }
       };
 

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1,3 +1,4 @@
+// this was copy-pasted from https://github.com/treyhuffine/lightbox-react and modified previously, Brent said
 /* eslint-disable react/sort-comp */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint react/destructuring-assignment: "off", no-mixed-operators: "off", max-len: "off", comma-dangle: "off" */


### PR DESCRIPTION
## Description
For null images, do not show "Image not found over current or other images"

## Jira Ticket
- [THEMES-107](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=760&modal=detail&selectedIssue=TMEDIA-107&assignee=5e387d6a1b1d910e5dfd7a9b&assignee=5de68894cdc2d20d05381036)

## Acceptance Criteria

Does not show "image not found" on lead art expand 

## Test Steps

- link engine-theme-sdk via .env 
- `npx fusion start`
- Go to http://localhost/pf/test-article-page/?_website=the-gazette
- Expand the lead art image. You should not see the "Image broken" overlay on top of the current image
- Scroll down and see the gallery. When you expand the gallery, the full-screen images should scroll as expected as before

## Effect Of Changes
### Before

<img width="892" alt="Screen Shot 2021-04-01 at 14 27 58" src="https://user-images.githubusercontent.com/5950956/113344294-7fe11680-92f6-11eb-8fdf-ff5c5bdbba1c.png">

<img width="945" alt="Screen Shot 2021-04-01 at 14 26 56" src="https://user-images.githubusercontent.com/5950956/113344158-558f5900-92f6-11eb-9ee7-558558c8a14f.png">

### After

- image expanded in lead art without error string overlaid 

<img width="727" alt="Screen Shot 2021-04-01 at 14 20 35" src="https://user-images.githubusercontent.com/5950956/113343413-68555e00-92f5-11eb-9e31-7f04236b6d71.png">

<img width="1436" alt="Screen Shot 2021-04-01 at 14 20 30" src="https://user-images.githubusercontent.com/5950956/113343516-87ec8680-92f5-11eb-899a-996da4a58b8a.png">


## Dependencies or Side Effects
_Examples of dependencies or side effects are:_

- none 

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [] Confirmed this PR has reasonable code coverage -> this area of the engine theme sdk had no code to start 🤦 
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing -> storybook build is passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored). -> this monoloith doesn't have any test and lots of global vars
- [x] Confirmed relevant documentation has been updated/added. -> relevant comments added

