### PR TITLE
TMEDIA-196 construct social media links

### DIFF
--- a/src/utils/constructSocialURL.test.ts
+++ b/src/utils/constructSocialURL.test.ts
@@ -1,0 +1,44 @@
+// dup with full author
+import constructSocialURL from './constructSocialURL';
+
+describe('construct social url helper', () => {
+  it('takes in  twitter as a field and returns interpolated string', () => {
+    expect(constructSocialURL('twitter', 'username')).toBe('https://twitter.com/username');
+  });
+  it('takes in  instagram as a field and returns interpolated string', () => {
+    expect(constructSocialURL('instagram', 'username')).toBe('https://www.instagram.com/username/');
+  });
+  it('takes in  facebook as a field and returns interpolated string', () => {
+    expect(constructSocialURL('facebook', 'https://www.thefacebook.com/zuck')).toBe('https://www.thefacebook.com/zuck');
+  });
+  it('takes in  reddit as a field and returns interpolated string', () => {
+    expect(constructSocialURL('reddit', 'username')).toBe('https://www.reddit.com/user/username/');
+  });
+  it('takes in  youtube as a field and returns interpolated string', () => {
+    expect(constructSocialURL('youtube', 'chasereeves')).toBe('https://www.youtube.com/user/chasereeves');
+  });
+  it('takes in  medium as a field and returns interpolated string', () => {
+    expect(constructSocialURL('medium', '@username')).toBe('https://medium.com/@username');
+  });
+  it('takes in  tumblr as a field and returns interpolated string', () => {
+    expect(constructSocialURL('tumblr', 'fishingboatproceeds')).toBe('https://fishingboatproceeds.tumblr.com');
+  });
+  it('takes in  pinterest as a field and returns interpolated string', () => {
+    expect(constructSocialURL('pinterest', 'username')).toBe('https://www.pinterest.com/username/');
+  });
+  it('takes in  snapchat as a field and returns interpolated string', () => {
+    expect(constructSocialURL('snapchat', 'username')).toBe('https://www.snapchat.com/add/username');
+  });
+  it('takes in  whatsapp as a field and returns interpolated string', () => {
+    expect(constructSocialURL('whatsapp', 'phonenum')).toBe('https://wa.me/phonenum');
+  });
+  it('takes in  linkedin as a field and returns interpolated string', () => {
+    expect(constructSocialURL('linkedin', 'username')).toBe('https://www.linkedin.com/in/username/');
+  });
+  it('takes in  rss as a field and returns interpolated string', () => {
+    expect(constructSocialURL('rss', 'www.blog-rss.com')).toBe('www.blog-rss.com');
+  });
+  it('takes in  soundcloud as a field and returns interpolated string', () => {
+    expect(constructSocialURL('soundcloud', 'username')).toBe('https://soundcloud.com/username');
+  });
+});

--- a/src/utils/constructSocialURL.test.ts
+++ b/src/utils/constructSocialURL.test.ts
@@ -1,4 +1,3 @@
-// dup with full author
 import constructSocialURL from './constructSocialURL';
 
 describe('construct social url helper', () => {

--- a/src/utils/constructSocialURL.ts
+++ b/src/utils/constructSocialURL.ts
@@ -1,0 +1,42 @@
+// dup with full author
+function constructSocialURL(type:string, field:string) {
+  switch (type) {
+    case 'email':
+      return `mailto:${field}`;
+    case 'twitter':
+      // https://twitter.com/jack
+      return `https://twitter.com/${field}`;
+    case 'instagram':
+      // https://www.instagram.com/zuck/
+      return `https://www.instagram.com/${field}/`;
+    case 'snapchat':
+      // https://www.snapchat.com/add/slc56
+      return `https://www.snapchat.com/add/${field}`;
+    case 'linkedin':
+      // https://www.linkedin.com/in/jackhowa/
+      return `https://www.linkedin.com/in/${field}/`;
+    case 'reddit':
+      // https://www.reddit.com/user/NotAnishKapoor/
+      return `https://www.reddit.com/user/${field}/`;
+    case 'youtube':
+      // https://www.youtube.com/user/chasereeves
+      return `https://www.youtube.com/user/${field}`;
+    case 'medium':
+      // weird requires @ signs
+      // https://medium.com/@dan_abramov
+      return `https://medium.com/${field}`;
+    case 'tumblr':
+      // john green https://fishingboatproceeds.tumblr.com
+      return `https://${field}.tumblr.com`;
+    case 'pinterest':
+      return `https://www.pinterest.com/${field}/`;
+    case 'soundcloud':
+      return `https://soundcloud.com/${field}`;
+    case 'whatsapp':
+      return `https://wa.me/${field}`;
+    default:
+      return field;
+  }
+}
+
+export default constructSocialURL;

--- a/src/utils/constructSocialURL.ts
+++ b/src/utils/constructSocialURL.ts
@@ -13,7 +13,7 @@ export enum SocialTypes {
   WhatsApp = 'whatsapp',
 }
 
-function constructSocialURL(type:string, field:string) {
+function constructSocialURL(type: string, field: string): string {
   switch (type) {
     case SocialTypes.Email:
       return `mailto:${field}`;

--- a/src/utils/constructSocialURL.ts
+++ b/src/utils/constructSocialURL.ts
@@ -1,38 +1,52 @@
-// dup with full author
+export enum SocialTypes {
+  Email = 'email',
+  Twitter = 'twitter',
+  Instagram = 'instagram',
+  Snapchat = 'snapchat',
+  LinkedIn = 'linkedin',
+  Reddit = 'reddit',
+  Youtube = 'youtube',
+  Medium = 'medium',
+  Tumblr = 'tumblr',
+  Pinterest = 'pinterest',
+  SoundCloud = 'soundcloud',
+  WhatsApp = 'whatsapp',
+}
+
 function constructSocialURL(type:string, field:string) {
   switch (type) {
-    case 'email':
+    case SocialTypes.Email:
       return `mailto:${field}`;
-    case 'twitter':
+    case SocialTypes.Twitter:
       // https://twitter.com/jack
       return `https://twitter.com/${field}`;
-    case 'instagram':
+    case SocialTypes.Instagram:
       // https://www.instagram.com/zuck/
       return `https://www.instagram.com/${field}/`;
-    case 'snapchat':
+    case SocialTypes.Snapchat:
       // https://www.snapchat.com/add/slc56
       return `https://www.snapchat.com/add/${field}`;
-    case 'linkedin':
+    case SocialTypes.LinkedIn:
       // https://www.linkedin.com/in/jackhowa/
       return `https://www.linkedin.com/in/${field}/`;
-    case 'reddit':
+    case SocialTypes.Reddit:
       // https://www.reddit.com/user/NotAnishKapoor/
       return `https://www.reddit.com/user/${field}/`;
-    case 'youtube':
+    case SocialTypes.Youtube:
       // https://www.youtube.com/user/chasereeves
       return `https://www.youtube.com/user/${field}`;
-    case 'medium':
+    case SocialTypes.Medium:
       // weird requires @ signs
       // https://medium.com/@dan_abramov
       return `https://medium.com/${field}`;
-    case 'tumblr':
+    case SocialTypes.Tumblr:
       // john green https://fishingboatproceeds.tumblr.com
       return `https://${field}.tumblr.com`;
-    case 'pinterest':
+    case SocialTypes.Pinterest:
       return `https://www.pinterest.com/${field}/`;
-    case 'soundcloud':
+    case SocialTypes.SoundCloud:
       return `https://soundcloud.com/${field}`;
-    case 'whatsapp':
+    case SocialTypes.WhatsApp:
       return `https://wa.me/${field}`;
     default:
       return field;

--- a/src/utils/constructSocialURL.ts
+++ b/src/utils/constructSocialURL.ts
@@ -1,4 +1,4 @@
-export enum SocialTypes {
+enum SocialTypes {
   Email = 'email',
   Twitter = 'twitter',
   Instagram = 'instagram',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export { default as localizeDate } from './localizeDate';
 export { default as localizeDateTime } from './localizeDateTime';
 export { default as extractVideoEmbedFromStory } from './extractVideoEmbedFromStory';
 export { default as isServerSide } from './serverSide';
+export { default as constructSocialURL } from './constructSocialURL';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,4 +2,4 @@ export { default as localizeDate } from './localizeDate';
 export { default as localizeDateTime } from './localizeDateTime';
 export { default as extractVideoEmbedFromStory } from './extractVideoEmbedFromStory';
 export { default as isServerSide } from './serverSide';
-export { default as constructSocialURL } from './constructSocialURL';
+export { default as constructSocialURL, SocialTypes as socialTypes } from './constructSocialURL';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,5 @@ export { default as localizeDate } from './localizeDate';
 export { default as localizeDateTime } from './localizeDateTime';
 export { default as extractVideoEmbedFromStory } from './extractVideoEmbedFromStory';
 export { default as isServerSide } from './serverSide';
-export { default as constructSocialURL, SocialTypes as socialTypes } from './constructSocialURL';
+export { default as constructSocialURL } from './constructSocialURL';
 export { default as formatURL } from './formatURL';

--- a/stories/constructSocialUrl.stories.mdx
+++ b/stories/constructSocialUrl.stories.mdx
@@ -1,0 +1,36 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utilities" />
+
+# Utility Methods 
+
+The SDK has a collection of utilities that help reduce redundant code.
+
+## Social Url Utility
+
+Import the `constructSocialUrl` method and `socialTypes`* object into your block
+
+`import { constructSocialUrl, socialTypes } from '@wpmedia/engine-theme-sdk';`
+
+and construct them by using one or more of the following:
+
+```
+constructSocialURL(socialTypes.Email, 'email@domain.tld');
+constructSocialURL(socialTypes.Twitter, '@TwitterUser');
+constructSocialURL(socialTypes.Instagram, 'InstaUser');
+constructSocialURL(socialTypes.Snapchat, 'SnapchatUser');
+constructSocialURL(socialTypes.LinkedIn, 'LinkedInUser');
+constructSocialURL(socialTypes.Reddit, 'RedditUser');
+constructSocialURL(socialTypes.Youtube, 'YoutubeChannel');
+constructSocialURL(socialTypes.Medium, '@MediumUser');
+constructSocialURL(socialTypes.Tumblr, 'TumblrUser');
+constructSocialURL(socialTypes.Pinterest, 'PinterestUser');
+constructSocialURL(socialTypes.SoundCloud, 'SoundCloudUser');
+constructSocialURL(socialTypes.WhatsApp, 'WhatsAppUser');
+```
+
+\* `socialTypes` is strictly a string enumeration of the types of social URLs we directly support.  If you know the exact string value required, you may pass this instead of utilizing the `socialTypes` identifiers, but we prefer if you use `socialTypes` identifiers for consistency and safety.
+
+## Feedback
+
+If you have feedback on this SDK or ideas for new functionality you’d like to see, contact us at https://ideas.arcpublishing.com/

--- a/stories/constructSocialUrl.stories.mdx
+++ b/stories/constructSocialUrl.stories.mdx
@@ -8,28 +8,26 @@ The SDK has a collection of utilities that help reduce redundant code.
 
 ## Social Url Utility
 
-Import the `constructSocialUrl` method and `socialTypes`* object into your block
+Import the `constructSocialUrl` method into your block
 
-`import { constructSocialUrl, socialTypes } from '@wpmedia/engine-theme-sdk';`
+`import { constructSocialUrl } from '@wpmedia/engine-theme-sdk';`
 
 and construct them by using one or more of the following:
 
 ```
-constructSocialURL(socialTypes.Email, 'email@domain.tld');
-constructSocialURL(socialTypes.Twitter, '@TwitterUser');
-constructSocialURL(socialTypes.Instagram, 'InstaUser');
-constructSocialURL(socialTypes.Snapchat, 'SnapchatUser');
-constructSocialURL(socialTypes.LinkedIn, 'LinkedInUser');
-constructSocialURL(socialTypes.Reddit, 'RedditUser');
-constructSocialURL(socialTypes.Youtube, 'YoutubeChannel');
-constructSocialURL(socialTypes.Medium, '@MediumUser');
-constructSocialURL(socialTypes.Tumblr, 'TumblrUser');
-constructSocialURL(socialTypes.Pinterest, 'PinterestUser');
-constructSocialURL(socialTypes.SoundCloud, 'SoundCloudUser');
-constructSocialURL(socialTypes.WhatsApp, 'WhatsAppUser');
+constructSocialURL('email', 'email@domain.tld');
+constructSocialURL('twitter', '@TwitterUser');
+constructSocialURL('instagram', 'InstaUser');
+constructSocialURL('snapchat', 'SnapchatUser');
+constructSocialURL('linkedin', 'LinkedInUser');
+constructSocialURL('reddit', 'RedditUser');
+constructSocialURL('youtube', 'YoutubeChannel');
+constructSocialURL('medium', '@MediumUser');
+constructSocialURL('tumblr', 'TumblrUser');
+constructSocialURL('pinterest', 'PinterestUser');
+constructSocialURL('soundcloud', 'SoundCloudUser');
+constructSocialURL('whatsapp', 'WhatsAppUser');
 ```
-
-\* `socialTypes` is strictly a string enumeration of the types of social URLs we directly support.  If you know the exact string value required, you may pass this instead of utilizing the `socialTypes` identifiers, but we prefer if you use `socialTypes` identifiers for consistency and safety.
 
 ## Feedback
 


### PR DESCRIPTION
## Description
Relocated and typed the constructSocialURL.js method for generating urls for social media from [fusion-news-theme-blocks](https://github.com/WPMedia/fusion-news-theme-blocks/tree/stable/blocks/author-bio-block/features/author-bio/shared)

## Jira Ticket
- [TMEDIA-196](https://arcpublishing.atlassian.net/browse/TMEDIA-196)

## Acceptance Criteria
N/A

## Test Steps
Un-available.  This change adds an import for the theme blocks to utilize.

## Dependencies or Side Effects
Impacts https://github.com/WPMedia/fusion-news-theme-blocks/pull/839 which is dependent on this change.

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
