### PR TITLE
TMEDIA-52 - Update lightbox for some accessibility items

### DIFF
--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -187,6 +187,9 @@ declare interface GalleryEventData {
 }
 
 describe('the gallery block', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="fusion-app"></div>';
+  });
   describe('the fullscreen button', () => {
     it('should be present with the "FullScreen" svg component with the correct fill', () => {
       const wrapper = shallow(<Gallery galleryElements={mockGallery} resizerURL="" />);

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -868,8 +868,6 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
      * Handle user keyboard actions
      */
     handleKeyInput(event): void {
-      event.stopPropagation();
-
       // Ignore key input during animations
       if (this.isAnimating()) {
         return;
@@ -901,7 +899,7 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
           this.requestClose(event);
           break;
 
-          // Left arrow key moves to previous image
+        // Left arrow key moves to previous image
         case KEYS.LEFT_ARROW:
           if (!this.props.prevSrc) {
             return;
@@ -912,7 +910,7 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
           this.requestMovePrev(event);
           break;
 
-          // Right arrow key moves to next image
+        // Right arrow key moves to next image
         case KEYS.RIGHT_ARROW:
           if (!this.props.nextSrc) {
             return;
@@ -1778,6 +1776,8 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
         },
       };
 
+      Modal.setAppElement('#fusion-app');
+
       return (
         <Modal
           isOpen
@@ -1785,14 +1785,13 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
           onAfterOpen={(): void => {
             // Focus on the div with key handlers
             if (this.outerEl) {
-              this.outerEl.focus();
+              this.outerEl.querySelector('#lightbox-close').focus();
             }
 
             onAfterOpen();
           }}
           style={modalStyle}
           contentLabel={translate('Lightbox')}
-          appElement={typeof window !== 'undefined' ? window.document.body : undefined}
           {...reactModalProps}
         >
           <LightboxContainer // eslint-disable-line jsx-a11y/no-static-element-interactions
@@ -1812,12 +1811,11 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
             onMouseDown={this.handleMouseDown}
             onTouchStart={this.handleTouchStart}
             onTouchMove={this.handleTouchMove}
-            tabIndex={-1} // Enables key handlers on div
             onKeyDown={this.handleKeyInput}
             onKeyUp={this.handleKeyInput}
           >
             <LightboxInnerDiv // eslint-disable-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-                        // Image holder
+              // Image holder
               className="ril-inner"
               onClick={clickOutsideToClose ? this.closeIfClickInner : undefined}
             >
@@ -1857,11 +1855,11 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
 
               <ul className="toolbarSide rightSide">
                 {toolbarButtons
-                            && toolbarButtons.map((button, i) => (
-                              <li key={`button_${i + 1}`} className="toolbarItem">
-                                {button}
-                              </li>
-                            ))}
+                  && toolbarButtons.map((button, i) => (
+                    <li key={`button_${i + 1}`} className="toolbarItem">
+                      {button}
+                    </li>
+                  ))}
 
                 {enableZoom && (
                 <li className="toolbarItem">
@@ -1879,10 +1877,10 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
                     }}
                     disabled={this.isAnimating() || zoomLevel === MAX_ZOOM_LEVEL}
                     onClick={
-                                            !this.isAnimating() && zoomLevel !== MAX_ZOOM_LEVEL
-                                              ? this.handleZoomInButtonClick
-                                              : undefined
-                                        }
+                      !this.isAnimating() && zoomLevel !== MAX_ZOOM_LEVEL
+                        ? this.handleZoomInButtonClick
+                        : undefined
+                    }
                   >
                     <ZoomInIcon width="100%" height="100%" fill="#fff" />
                   </button>
@@ -1905,10 +1903,10 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
                     }}
                     disabled={this.isAnimating() || zoomLevel === MIN_ZOOM_LEVEL}
                     onClick={
-                                            !this.isAnimating() && zoomLevel !== MIN_ZOOM_LEVEL
-                                              ? this.handleZoomOutButtonClick
-                                              : undefined
-                                        }
+                      !this.isAnimating() && zoomLevel !== MIN_ZOOM_LEVEL
+                        ? this.handleZoomOutButtonClick
+                        : undefined
+                    }
                   >
                     <ZoomOutIcon width="100%" height="100%" fill="#fff" />
                   </button>
@@ -1919,7 +1917,7 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
                   <button // Lightbox close button
                     type="button"
                     key="close"
-                    title={this.props.closeLabel}
+                    id="lightbox-close"
                     aria-label={this.props.closeLabel}
                     className="itemChild builtinButton"
                     onClick={!this.isAnimating() ? this.requestClose : undefined}


### PR DESCRIPTION
## Description

Update code to keep focus within the Modal (Lightbox) when opened
Set focus to close button upon opening, per expectations

## Jira Ticket
- [TMEDIA-52](https://arcpublishing.atlassian.net/browse/TMEDIA-52)

## Acceptance Criteria
Keyboard users should be able to access and operate the light box elements appropriately.

## Test Steps
1. Link SDK to Theme block repo using `ENGINE_SDK_REPO` env variable
2. Run fusion repo using `npx fusion start -f -l`
3. Goto page with Gallery - http://localhost/gallery/2021/02/09/the-scene-as-astronaut-christina-koch-returns-to-earth-after-historic-tour-aboard-the-international-space-station/?_website=the-gazette
4. Verify when you click Expand above gallery you can
    * Only tab to buttons within the lightbox - you do not leave the lightbox
    * Focus is set to close button upon open
    * On close focus is passed back to the Expand

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
