### PR TITLE
TMEDIA-27/29/30/31 - Gallery accessibility updates

### DIFF
--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -258,10 +258,13 @@ describe('the gallery block', () => {
     });
 
     it('should accurately reflect the current state during autoplay', () => {
-      const wrapper = mount(<Gallery galleryElements={mockGallery} resizerURL="" />);
+      const wrapper = mount(<Gallery galleryElements={mockGallery} resizerURL="" ansId="abc" />);
+
+      expect(wrapper.find('#gallery-images-abc').at(0).prop('aria-live')).toBe('polite');
       const autoButtonWrapper = wrapper.find('styled__ControlContainer').find('button').at(1);
       expect(autoButtonWrapper.childAt(1).text()).toBe('Autoplay');
       autoButtonWrapper.simulate('click');
+      expect(wrapper.find('#gallery-images-abc').at(0).prop('aria-live')).toBe('off');
       expect(autoButtonWrapper.childAt(1).text()).toMatch(/Pause\sautoplay/);
       autoButtonWrapper.simulate('click');
       expect(autoButtonWrapper.childAt(1).text()).toMatch(/Autoplay/);
@@ -383,6 +386,14 @@ describe('the gallery block', () => {
 
     afterEach(() => {
       document.body.removeChild(outerNode);
+    });
+
+    it('should have aria label and roledescription on container', () => {
+      const ansHeadlineText = 'Headline Text';
+      const wrapper = shallow(<Gallery galleryElements={mockGallery} resizerURL="" ansHeadline={ansHeadlineText} />);
+
+      expect(wrapper.at(0).prop('aria-label')).toBe(ansHeadlineText);
+      expect(wrapper.at(0).prop('aria-roledescription')).toBe('carousel');
     });
 
     it('should render all the images with the correct inital x offset', () => {

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -41,7 +41,6 @@ import {
   ControlsButton,
   PlaybackText,
   ImageCountText,
-  ScreenReaderText,
   CarouselContainer,
   CarouselButton,
   ImageWrapper,

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -41,6 +41,7 @@ import {
   ControlsButton,
   PlaybackText,
   ImageCountText,
+  ScreenReaderText,
   CarouselContainer,
   CarouselButton,
   ImageWrapper,
@@ -93,6 +94,10 @@ interface GalleryProps {
   ansHeadline?: string;
   galleryElements?: GalleryElement[];
   expandPhrase?: string;
+  autoplayPhraseLabels?: {
+    start?: string;
+    stop?: string;
+  };
   autoplayPhrase?: string;
   pausePhrase?: string;
   pageCountPhrase?: (current: number, total: number) => string;
@@ -113,6 +118,7 @@ const Gallery: React.FC<GalleryProps> = ({
   ansHeadline = '',
   expandPhrase,
   autoplayPhrase,
+  autoplayPhraseLabels = {},
   pausePhrase,
   pageCountPhrase,
   interstitialClicks,
@@ -343,6 +349,7 @@ const Gallery: React.FC<GalleryProps> = ({
     imgContent: GalleryElement,
     index: number,
     showAd: boolean,
+    totalImages: number,
   ): React.ReactElement => (
     <ImageWrapper
       key={`gallery-image-${imgContent._id}`}
@@ -354,6 +361,10 @@ const Gallery: React.FC<GalleryProps> = ({
           : `translate(${-100 * page}%, 0)`,
         transitionDuration: slide.isSliding ? '0s' : '1s',
       }}
+      role="group"
+      aria-roledescription="slide"
+      aria-label={`${index + 1} of ${totalImages}`}
+      aria-hidden={index !== page}
     >
       { showAd && renderAd() }
       <Image
@@ -394,8 +405,20 @@ const Gallery: React.FC<GalleryProps> = ({
     };
   });
 
+  const ImageCountTextOutput = {
+    __html: (pageCountPhrase
+      ? pageCountPhrase(page + 1, galleryElements.length)
+      : (
+        `<span>Image</span> ${page + 1} of ${galleryElements.length}`
+      )),
+  };
+
   return (
-    <GalleryDiv ref={galleryRef}>
+    <GalleryDiv
+      ref={galleryRef}
+      aria-roledescription="carousel"
+      aria-label={ansHeadline}
+    >
       <ControlsDiv>
         <ControlContainer>
           <ControlsButton type="button" onClick={(): void => fullScreen()}>
@@ -406,24 +429,18 @@ const Gallery: React.FC<GalleryProps> = ({
             {autoDuration ? (
               <>
                 <PauseIcon fill={greyFill} />
-                <PlaybackText>{pausePhrase || 'Pause autoplay'}</PlaybackText>
+                <PlaybackText aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}>{pausePhrase || 'Pause autoplay'}</PlaybackText>
               </>
             ) : (
               <>
                 <PlayIcon fill={greyFill} />
-                <PlaybackText>{autoplayPhrase || 'Autoplay'}</PlaybackText>
+                <PlaybackText aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}>{autoplayPhrase || 'Autoplay'}</PlaybackText>
               </>
             )}
           </ControlsButton>
         </ControlContainer>
         <ControlContainer>
-          <ImageCountText>
-            {
-              pageCountPhrase
-                ? pageCountPhrase(page + 1, galleryElements.length)
-                : `${page + 1} of ${galleryElements.length}`
-            }
-          </ImageCountText>
+          <ImageCountText dangerouslySetInnerHTML={ImageCountTextOutput} />
           <ControlsButton type="button" aria-label={previousImagePhrase} onClick={(): void => prevHandler()}>
             <ChevronLeftIcon fill={greyFill} />
           </ControlsButton>
@@ -432,9 +449,13 @@ const Gallery: React.FC<GalleryProps> = ({
           </ControlsButton>
         </ControlContainer>
       </ControlsDiv>
-      <CarouselContainer {...handlers}>
+      <CarouselContainer
+        id={`gallery-images-${ansId}`}
+        {...handlers}
+        aria-live={autoDuration ? 'off' : 'polite'}
+      >
         { galleryElements.map((imgContent, index): React.ReactElement => (
-          renderImage(imgContent, index, isAdActive() && isAdInPage(index))
+          renderImage(imgContent, index, isAdActive() && isAdInPage(index), galleryElements.length)
         ))}
         <CarouselButton type="button" aria-label={previousImagePhrase} className="prev-button" onClick={(): void => prevHandler()}>
           <ChevronLeftIcon width="100%" height="100%" fill="white" />
@@ -493,6 +514,11 @@ Gallery.propTypes = {
   expandPhrase: PropTypes.string,
   /** Autoplay phrase text for internationalization */
   autoplayPhrase: PropTypes.string,
+  /** Object of phases for stop and start labels of Autoplay button */
+  autoplayPhraseLabels: PropTypes.shape({
+    start: PropTypes.string,
+    stop: PropTypes.string,
+  }),
   /** Pause phrase text for internationalization */
   pausePhrase: PropTypes.string,
   /** Page count phrase text for internationalization */

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -75,9 +75,6 @@ export const ImageCountText = styled.p`
   }
 `;
 
-export const ScreenReaderText = styled.span`
-`;
-
 export const CarouselContainer = styled.div`
   position: relative;
   overflow: hidden;

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import rem from 'polished/lib/helpers/rem';
 
-export const GalleryDiv = styled.div`
+export const GalleryDiv = styled.section`
   display: block;
   width: 100%;
   overflow: hidden;
@@ -61,8 +61,21 @@ export const PlaybackText = styled.span`
   margin: 0 30px 0 4px;
 `;
 
-export const ImageCountText = styled.span`
-  margin-left: 12px;
+export const ImageCountText = styled.p`
+  display: inline-block;
+  margin: 0 0 0 12px;
+
+  span {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+  }
+`;
+
+export const ScreenReaderText = styled.span`
 `;
 
 export const CarouselContainer = styled.div`

--- a/stories/Gallery.stories.mdx
+++ b/stories/Gallery.stories.mdx
@@ -199,7 +199,7 @@ import { Gallery } from '@wpmedia/engine-theme-sdk';
                 version: 0,
                 },
                 address: {},
-                alt_text: text("Alt Text", "This is an alt text"),
+                alt_text: 'This is an alt text for image 2',
                 caption: text("Caption", "Override the caption on this image for this particular gallery"),
                 credits: {
                 affiliation: [],
@@ -311,7 +311,7 @@ import { Gallery } from '@wpmedia/engine-theme-sdk';
                 version: 0,
                 },
                 address: {},
-                alt_text: text("Alt Text", "This is an alt text"),
+                alt_text: 'This is an alt text for image 3',
                 caption: text("Caption", "Override the caption on this image for this particular gallery"),
                 created_date: '2019-07-09T22:26:02Z',
                 credits: {
@@ -441,7 +441,7 @@ import { Gallery } from '@wpmedia/engine-theme-sdk';
                 version: 1,
                 },
                 address: {},
-                alt_text: text("Alt Text", "This is an alt text"),
+                alt_text: 'This is an alt text for image 4',
                 caption: text("Caption", "Override the caption on this image for this particular gallery"),
                 created_date: '2019-07-09T23:03:02Z',
                 credits: {

--- a/stories/Gallery.stories.mdx
+++ b/stories/Gallery.stories.mdx
@@ -10,7 +10,7 @@ The `Gallery` component is used to display galleries created in [Photo Center](h
 
 ## Use
 
-Import it into a block: 
+Import it into a block:
 
 ```
 import { Gallery } from '@wpmedia/engine-theme-sdk';
@@ -24,6 +24,7 @@ import { Gallery } from '@wpmedia/engine-theme-sdk';
     ansHeadline={item.headlines.basic ? item.headlines.basic : ''}
     expandPhrase={phrases.t('global.gallery-expand-button')}
     autoplayPhrase={phrases.t('global.gallery-autoplay-button')}
+    autoplayPhraseLabels={{ start: phrases.t('global.gallery-autoplay-phrase-start'), stop: phrases.t('global.gallery-autoplay-phrase-stop') }}
     pausePhrase={phrases.t('global.gallery-pause-autoplay-button')}
     pageCountPhrase={(current, total) => phrases.t('global.gallery-page-count-text', { current, total })}
     interstitialClicks={2}
@@ -3465,5 +3466,3 @@ import { Gallery } from '@wpmedia/engine-theme-sdk';
         />
     </Story>
 </Canvas>
-
-


### PR DESCRIPTION
## Description

Update to gallery to be more accessible by

* Providing better labelling on auto play button - and allowing consumers to pass in their own phrases
* Using aria where needed to mark up gallery carousel correctly
* Update ImageCountText to set HTML to allow consumers to pass in HTML with content such as ```"<span class='sr-only'>Image</span> %{current} of %{total}"``` to allow the Image word that provides context to be hidden from view

## Jira Ticket
- [TMEDA-27](https://arcpublishing.atlassian.net/browse/TMEDIA-27)
- [TMEDA-29](https://arcpublishing.atlassian.net/browse/TMEDIA-29)
- [TMEDA-30](https://arcpublishing.atlassian.net/browse/TMEDIA-30)
- [TMEDA-31](https://arcpublishing.atlassian.net/browse/TMEDIA-31)

## Test Steps

Using storybook to test component. You will also need to be using a Screen reader. Mac has a built in one called VoiceOver. If testing with VoiceOver, it's best paired with Safari.

* Checkout this branch `git checkout TMEDIA-27-29-30-31-gallery-a11y-updates`
* Run storybook from root of checkout branch - `npm run storybook`
* Have screen reader turned on

1. Testing for auto play label
    * Open storybook - http://localhost:6006/?path=/story/gallery--custom-gallery
    * Using your keyboard tab to the "Autoplay" button
    * Verify the screen reader reads - Start automatic slide show
    * Press Enter to start
    * Tab away and back
    * Verify screen reader reads - Stop automatic slide show


2. Testing for image change be announced when using next / previous buttons
    * Open storybook - http://localhost:6006/?path=/story/gallery--custom-gallery
    * Tab to the next button and wait for screen reader to finish reading and hit enter to trigger the next button
    * Validate the next image's alt text is read to you and none of the others
    * Now shift tab to go to previous button - wait for screen reader to finish reading instructions - hit enter
    * Validate the previous image's alt text is read to you and none of the others
 
3. Testing "Image X of X" is read correctly
    * Open storybook - http://localhost:6006/?path=/story/gallery--custom-gallery
    * Using your keyboard arrow keys navigate to the text that shows on the screen as 1 of 9
    * When on text using the VoiceOver keyboard shortcut - VO+S - VO stands for VoiceOver modifier key


## Effect Of Changes

No visual changes should be introduced, these are all accessibility updates that focus on screen reader users


## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps above are working
- [X] Confirmed there are no linter errors
- [X] Confirmed this PR has reasonable code coverage
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm test`, made sure all tests are passing
- [X] Confirmed relevant documentation has been updated/added.
