### PR TITLE
Add visibility style to images not in view

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -359,6 +359,7 @@ const Gallery: React.FC<GalleryProps> = ({
           ? `translate(calc(${-100 * page}% - ${slide.delta}px), 0)`
           : `translate(${-100 * page}%, 0)`,
         transitionDuration: slide.isSliding ? '0s' : '1s',
+        visibility: (index !== page && !slide.isSliding) ? 'hidden' : null,
       }}
       role="group"
       aria-roledescription="slide"

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -106,7 +106,7 @@ export const ImageWrapper = styled.div`
   width: 100%;
   height: 100%;
   display: inline-block;
-  transition-property: transform;
+  transition-property: transform, visibility;
 
   img {
     object-fit: contain;


### PR DESCRIPTION
## Description

Fix issue where voice over selects next image when using VO + arrow keys to navigate through the page

## Jira Ticket
- [TMEDIA-31](https://arcpublishing.atlassian.net/browse/TMEDIA-31)

## Test Steps

Using storybook to test component. You will also need to be using a Screen reader. Mac has a built in one called VoiceOver. If testing with VoiceOver, it's best paired with Safari.

* Checkout this branch `git checkout TMEDIA-31-image-selection-issue`
* Run storybook from root of checkout branch - `npm run storybook`
* Have screen reader turned on

Using VO + right key navigate through the page and verify only the image in view is selected

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [X] Confirmed all the test steps above are working
- [X] Confirmed there are no linter errors
- [X] Confirmed this PR has reasonable code coverage
  - [X] Confirmed this PR has unit test files
  - [X] Ran `npm test`, made sure all tests are passing
  - [X] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [X] Confirmed relevant documentation has been updated/added.
