### PR TITLE
Add threshold for chromatic to reduce noise

### DIFF
--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -1,7 +1,14 @@
 import Image from "../src/components/Image";
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
-<Meta title="Image" component={Image} />
+<Meta
+  title="Image"
+  component={Image}
+  parameters={{
+    // Setting a high threshold to over come noise created in chromatic
+    chromatic: { diffThreshold: 1 }
+  }}
+/>
 
 # Image
 

--- a/stories/Video.stories.mdx
+++ b/stories/Video.stories.mdx
@@ -2,7 +2,14 @@ import Video from '../src/components/Video';
 import { text } from "@storybook/addon-knobs";
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 
-<Meta title="Video" component={Video} />
+<Meta
+    title="Video"
+    component={Video}
+    parameters={{
+        // Setting a high threshold to over come noise created in chromatic
+        chromatic: { diffThreshold: 1 }
+    }}
+/>
 
 # Video
 
@@ -15,7 +22,7 @@ The playerRoot and videoOrg Fusion environment variables must be defined in orde
 
 ## Use
 
-Import it into a block: 
+Import it into a block:
 
 ```
 import { Video } from '@wpmedia/engine-theme-sdk';

--- a/stories/VideoPlayer.stories.mdx
+++ b/stories/VideoPlayer.stories.mdx
@@ -2,7 +2,14 @@ import VideoPlayer from '../src/components/VideoPlayer';
 import { text } from "@storybook/addon-knobs";
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 
-<Meta title="VideoPlayer" component={VideoPlayer} />
+<Meta
+    title="VideoPlayer"
+    component={VideoPlayer}
+    parameters={{
+        // Setting a high threshold to over come noise created in chromatic
+        chromatic: { diffThreshold: 1 }
+    }}
+/>
 
 ### **Video Player with minimum configurations**
 <Canvas>


### PR DESCRIPTION
Adjust threshold value of Video and Image stories for Chromatic to reduce the false positives in chromatic runs

Docs - https://www.chromatic.com/docs/threshold

> The diffThreshold parameter allows you to fine tune the threshold for visual change between snapshots before they’re flagged by Chromatic. Sometimes you need assurance to the sub-pixel and other times you want to skip visual noise generated by non-deterministic rendering such as anti-aliasing.