### PR TITLE
TMEDIA-227: Ensure first level of accessible contrast level

### DIFF
--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -25,7 +25,7 @@ interface ImageMetadataProps {
 const MetadataParagraph = styled.p<{ primaryFont: string }>`
   font-family: ${(props): string => props.primaryFont};
   font-size: 14px;
-  color: #6C7089;
+  color: #6c7778;
   margin: 8px 0;
   line-height: 16px;
 
@@ -34,7 +34,7 @@ const MetadataParagraph = styled.p<{ primaryFont: string }>`
   }
 
   .title {
-    color: #6C7089;
+    color: #6c7778;
     font-weight: bold;
   }
 `;

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -25,7 +25,7 @@ interface ImageMetadataProps {
 const MetadataParagraph = styled.p<{ primaryFont: string }>`
   font-family: ${(props): string => props.primaryFont};
   font-size: 14px;
-  color: #6c7778;
+  color: #6C7089;
   margin: 8px 0;
   line-height: 16px;
 
@@ -34,7 +34,7 @@ const MetadataParagraph = styled.p<{ primaryFont: string }>`
   }
 
   .title {
-    color: #6c7778;
+    color: #6C7089;
     font-weight: bold;
   }
 `;

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -25,7 +25,7 @@ interface ImageMetadataProps {
 const MetadataParagraph = styled.p<{ primaryFont: string }>`
   font-family: ${(props): string => props.primaryFont};
   font-size: 14px;
-  color: #7F8C8D;
+  color: #6c7778;
   margin: 8px 0;
   line-height: 16px;
 
@@ -34,7 +34,7 @@ const MetadataParagraph = styled.p<{ primaryFont: string }>`
   }
 
   .title {
-    color: #7F8C8D;
+    color: #6c7778;
     font-weight: bold;
   }
 `;


### PR DESCRIPTION
blocks-related test instructions ... https://github.com/WPMedia/fusion-news-theme-blocks/pull/901

ac: Update relevant text color to be #6c7778 so it passes this color contrast audit

# Test Instructions
- `npm run storybook` 
- look at custom gallery and accessibility warnings. should be none now 
- using rec'd color #6c7778 via https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-227

before 

<img width="1194" alt="Screen Shot 2021-04-30 at 15 23 39" src="https://user-images.githubusercontent.com/5950956/116751486-b54a5400-a9c9-11eb-84ef-60667ad450e3.png">

after 

<img width="1380" alt="Screen Shot 2021-06-10 at 09 34 04" src="https://user-images.githubusercontent.com/5950956/121545062-caa29d00-c9cf-11eb-893c-ee457e05003e.png">





related to #209 for metadata on images 