### PR TITLE
Tmedia 16 document migration to videoplayer

### DIFF
--- a/src/components/VideoPlayer/formatEmbedMarkup.test.tsx
+++ b/src/components/VideoPlayer/formatEmbedMarkup.test.tsx
@@ -72,4 +72,16 @@ describe('If the embed html is valid', () => {
       '"<div class=\\"powa\\" id=\\"powa-e924\\" data-org=\\"corecomponents\\" data-env=\\"prod\\" data-uuid=\\"e924e51b\\" data-aspect-ratio=\\"0.562\\" data-api=\\"prod\\"><script src=\\"//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents\\"></script></div>"',
     );
   });
+  it('passes in an override aspect ratio', () => {
+    const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
+    + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
+    + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+
+    // 0.3 target aspect ratio
+    const embedHTMLOutput = formatEmbedMarkup(testEmbed, false, false, 0.3);
+
+    expect(embedHTMLOutput).toMatch(/data-aspect-ratio="0.3"/i);
+    // 0.562 was passed in default
+    expect(embedHTMLOutput).not.toMatch(/data-aspect-ratio="0.562"/i);
+  });
 });

--- a/src/components/VideoPlayer/formatEmbedMarkup.tsx
+++ b/src/components/VideoPlayer/formatEmbedMarkup.tsx
@@ -16,11 +16,13 @@ function convertStringToNode(string: string): HTMLElement {
  * @param {string} embedHTML is html that has powa info
  * @param {boolean} enableAutoplay sets video to autoplay
  * @param {boolean} playthrough sets video to continue playing through
+ * @param {number} overrideAspectRatio overrides aspect ratio. Could be undefined
  */
 function formatEmbedMarkup(
   embedHTML: string,
   enableAutoplay: boolean,
   playthrough: boolean,
+  overrideAspectRatio?: number,
 ): string {
   if (embedHTML) {
     const embedHTMLWithPlayStatus = convertStringToNode(embedHTML).querySelector('div');
@@ -32,6 +34,10 @@ function formatEmbedMarkup(
 
     if (playthrough) {
       embedHTMLWithPlayStatus.setAttribute('data-playthrough', 'true');
+    }
+
+    if (overrideAspectRatio) {
+      embedHTMLWithPlayStatus.setAttribute('data-aspect-ratio', overrideAspectRatio.toString());
     }
 
     return embedHTMLWithPlayStatus.outerHTML;

--- a/src/components/VideoPlayer/index.test.tsx
+++ b/src/components/VideoPlayer/index.test.tsx
@@ -11,6 +11,15 @@ test('renders id with video tag to match with powa player', () => {
   expect(matchingVideoTargetIdDiv.getAttribute('id')).toBe('video-matching123');
 });
 
+test('renders uuid with video tag to match with powa player', () => {
+  const targetId = 'matching123';
+  const videoPlayer = render(<VideoPlayer embedMarkup="" uuid={targetId} />);
+
+  // id not usually important in rtl but this is an exception
+  const matchingVideoTargetIdDiv = videoPlayer.container.querySelector(`#video-${targetId}`);
+  expect(matchingVideoTargetIdDiv.getAttribute('id')).toBe('video-matching123');
+});
+
 test('renders embed markup in container', () => {
   const targetId = '';
   const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -16,10 +16,13 @@ interface CustomFields {
 
 interface VideoPlayerProps {
   embedMarkup: string;
-  id: string;
+  id?: string;
   enableAutoplay?: boolean;
   customFields?: CustomFields;
   isPlaythrough?: boolean;
+  /* @deprecated Use id prop instead */
+  uuid?: string;
+  aspectRatio?: number;
 }
 
 const EmbedVideoContainer = styled.div`
@@ -40,17 +43,23 @@ const EmbedVideoContainer = styled.div`
  * @param {boolean} enableAutoplay sets video to autoplay per user settings
  * @param {boolean} isPlaythrough is preferred way of setting playthrough in video
  * @param {object} customFields is deprecated but takes in values like the block video player.
+ * @param {string} uuid corresponds to the video-{id} player loaded by powa video player
  */
 const VideoPlayer: React.FC<VideoPlayerProps> = ({
   embedMarkup,
-  id,
+  id = '',
+  uuid = '',
   enableAutoplay = false,
   customFields = {},
   isPlaythrough = false,
   aspectRatio: overrideAspectRatio,
 }) => {
+  // migration from video component
+  // will fallback to uuid if id is undefined with defaulting to falsy ''
+  const targetId = id || uuid;
+
   const { playthrough = false, autoplay = false } = customFields;
-  const videoRef = useRef(id);
+  const videoRef = useRef(targetId);
   const shouldRender = !!(
     typeof window !== 'undefined'
     && typeof document !== 'undefined'

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -47,6 +47,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   enableAutoplay = false,
   customFields = {},
   isPlaythrough = false,
+  aspectRatio: overrideAspectRatio,
 }) => {
   const { playthrough = false, autoplay = false } = customFields;
   const videoRef = useRef(id);
@@ -69,6 +70,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       embedMarkup,
       enableAutoplay || autoplay,
       isPlaythrough || playthrough,
+      overrideAspectRatio,
     )
   );
 

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -77,7 +77,6 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         if (window.powaBoot) window.powaBoot();
       }
     }
-    // only run on mount with []
   }, [shouldRender]);
 
   const getEmbedHTMLWithPlayStatus = (): string => (

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -3,21 +3,6 @@ import EmbedContainer from 'react-oembed-container';
 import styled from 'styled-components';
 import formatEmbedMarkup from './formatEmbedMarkup';
 
-/**
-    autoplay,
-    // can't support global content
-    // inheritGlobalContent,
-    playthrough,
-    alertBadge,
-    title,
-    description,
-
-    // can't support websiteURL and
-    // i think it's deprecated anyway
-    // bc fetching
-    // websiteURL,
-  * */
-
 interface CustomFields {
   /* @deprecated Use isPlaythrough prop directly instead */
   playthrough?: boolean;

--- a/video-component-to-video-player-component-migration.md
+++ b/video-component-to-video-player-component-migration.md
@@ -22,8 +22,3 @@ Furthermore, the `<VideoPlayer />` only loads on the client-side. A server-side 
 ## Breaking Changes 
 
 - `aspectRatio` will default to what's passed inside the embed markup script rather than defaulting to `0.562`. You can still override the `aspectRatio` if specified.
-
-
-
-
-

--- a/video-component-to-video-player-component-migration.md
+++ b/video-component-to-video-player-component-migration.md
@@ -1,0 +1,29 @@
+# How And Why To Migrate From <Video /> to <VideoPlayer />
+
+## Why?
+
+### Faster Page Speeds With <VideoPlayer />
+
+The `<Video />` requires output types to load powaboot and powadrive scripts on every page, even when there's no video. Yet the embed markup included already includes those required scripts. Therefore, those scripts will be loaded only when needed using the `<VideoPlayer />`.
+
+Furthermore, the `<VideoPlayer />` only loads on the client-side. A server-side render of the video slowed down the page (and resulted in bugs in some cases). 
+
+## How
+
+1. Replace `<Video>` with `<VideoPlayer>` in the import from `engine-theme-sdk` and usage.
+2. Extract `embed_html` from ans object. If you need a utility to do so, please use `extractVideoEmbedFromStory` from `@wpmedia/engine-theme-sdk`. Pass in the html as `embedMarkup` to `<VideoPlayer />`. The html will look like: 
+
+```html
+<div class="powa" id="powa-e924e51b" data-org="corecomponents" data-env="prod" data-uuid="powa-e924e51b" data-aspect-ratio="0.562" data-api="prod"><script src="//111.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+
+```
+3. Remove powaBoot.js and powaDrive.js from output types. See [example](https://github.com/WPMedia/fusion-news-theme-blocks/commit/6e1ac8cbcb11539936130c9d4215c454c7d96661) for migration.
+
+## Breaking Changes 
+
+- `aspectRatio` will default to what's passed inside the embed markup script rather than defaulting to `0.562`. You can still override the `aspectRatio` if specified.
+
+
+
+
+


### PR DESCRIPTION
## Description
- Add migration path from video to videoplayer
- Ensure compatibility of props 

## Jira Ticket
- [TMEDIA-16](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-16&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria

If it is necessary to have two separate components, document their different use cases -> the different usecases can only be due to the scripts loading at the root. that shouldn't be necessary with embed markup

Need to check with Cheng-Hsin to see if he is still using the first one, like in the Golden State Warriors -> I've spoken with @joeymarburger and they are still using <video /> component. I've given a doc for Joey to review once completed so we can deprecate or delete the video component in favor of the videoplayer component. 

## Test Steps
- Look at tests to verify compatibility between video and videoplayer (uuid and id) and aspect ratio

## Effect Of Changes
### Before
- video and videoplayer were compatible 

### After
- migration path documented 
- explained the perf benefits of using videoplayer 

## Dependencies or Side Effects
- aspectRatio will default to the embed markup's native aspect ratio rather than the hard-coded one 

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
