### PR TITLE
TMEDIA-231 : Add an optional setting to confine video heights in bloc…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,15 @@
         "tunnel": "0.0.6"
       }
     },
+    "@arc-fusion/prop-types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@arc-fusion/prop-types/-/prop-types-0.1.5.tgz",
+      "integrity": "sha512-12/1QGXYaGZWDw1vnTX8fltWf3BA7zc95Kn9MyXD/PhFAJBEbpvtD2R+NZ8NU+DMPYlYLP33tyI3NSddERZCAA==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "@babel/cli": {
       "version": "7.13.14",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.13.14.tgz",

--- a/package.json
+++ b/package.json
@@ -83,9 +83,11 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
     "jest-enzyme": "^7.1.2",
+    "styled-components": "^4.4.1",
     "typescript": "^4.1.5"
   },
   "dependencies": {
+    "@arc-fusion/prop-types": "^0.1.5",
     "dom-parser": "^0.1.6",
     "is-react": "^1.3.3",
     "lazy-child": "^0.2.0",

--- a/src/components/Video/index.test.jsx
+++ b/src/components/Video/index.test.jsx
@@ -18,7 +18,6 @@ describe('Video', () => {
       expect(videoElement.prop('data-autoplay')).toBe(false);
       expect(videoElement.prop('data-playthrough')).toBe(false);
       expect(videoElement.prop('data-muted')).toBe(false);
-      expect(videoElement.prop('data-aspect-ratio')).toBe(0.5625);
       expect(global.powaBoot).toBeCalled();
     });
   });
@@ -34,7 +33,6 @@ describe('Video', () => {
       expect(videoElement.prop('data-autoplay')).toBe(true);
       expect(videoElement.prop('data-playthrough')).toBe(false);
       expect(videoElement.prop('data-muted')).toBe(true);
-      expect(videoElement.prop('data-aspect-ratio')).toBe(0.5625);
       expect(global.powaBoot).toBeCalled();
     });
   });
@@ -50,14 +48,13 @@ describe('Video', () => {
       expect(videoElement.prop('data-autoplay')).toBe(false);
       expect(videoElement.prop('data-playthrough')).toBe(true);
       expect(videoElement.prop('data-muted')).toBe(false);
-      expect(videoElement.prop('data-aspect-ratio')).toBe(0.5625);
       expect(global.powaBoot).toBeCalled();
     });
   });
 
   describe('with aspectRatio defined', () => {
     it('set aspectRatio data attribute to 0.75 and call window.powaBoot', () => {
-      const wrapper = mount(<Video uuid="video-uuid" org="corecomponents" env="prod" aspectRatio={0.75} />);
+      const wrapper = mount(<Video uuid="video-uuid" org="corecomponents" env="prod" />);
       const videoElement = wrapper.find('.powa').at(0);
       expect(videoElement.prop('id')).toBe('powa-video-uuid');
       expect(videoElement.prop('data-org')).toBe('corecomponents');
@@ -66,8 +63,51 @@ describe('Video', () => {
       expect(videoElement.prop('data-autoplay')).toBe(false);
       expect(videoElement.prop('data-playthrough')).toBe(false);
       expect(videoElement.prop('data-muted')).toBe(false);
-      expect(videoElement.prop('data-aspect-ratio')).toBe(0.75);
       expect(global.powaBoot).toBeCalled();
+    });
+  });
+});
+
+describe('Styling', () => {
+  beforeEach(() => {
+    global.powaBoot = jest.fn();
+  });
+
+  describe('shrinkToFit flag on Video', () => {
+    it('not included, the video should still render with a false flag passed to the wrapper', () => {
+      const wrapper = mount(
+        <Video uuid="video-uuid" org="corecomponents" env="prod" />,
+      );
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(false);
+    });
+
+    it('included, the video should still render with a true flag passed to the wrapper', () => {
+      const wrapper = mount(
+        <Video uuid="video-uuid" org="corecomponents" env="prod" shrinkToFit />,
+      );
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(true);
+    });
+  });
+});
+
+describe('MutationObserver', () => {
+  describe('video aspect ratio', () => {
+    it('should not be calculated given a zero dimension video', () => {
+      global.MutationObserver = jest.fn((observe) => ({ observe }));
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({ width: 0, height: 0 }));
+      const wrapper = mount(
+        <Video uuid="video-uuid" org="corecomponents" env="prod" />,
+      );
+      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(0.5625); // default aspect ratio
+    });
+
+    it('should be calculated given a known dimension video', () => {
+      global.MutationObserver = jest.fn((observe) => ({ observe }));
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({ width: 10, height: 10 }));
+      const wrapper = mount(
+        <Video uuid="video-uuid" org="corecomponents" env="prod" />,
+      );
+      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(1); // square aspect ratio
     });
   });
 });

--- a/src/components/Video/index.test.jsx
+++ b/src/components/Video/index.test.jsx
@@ -91,10 +91,19 @@ describe('Styling', () => {
 });
 
 describe('MutationObserver', () => {
+  beforeEach(() => {
+    global.MutationObserver = class MutationObserver extends global.MutationObserver {
+      constructor(callback) {
+        super(callback);
+      }
+      disconnect() {}
+      observe(element, initObject) {}
+    };
+  });
+
   describe('video aspect ratio', () => {
     it('should not be calculated given a zero dimension video', () => {
-      global.MutationObserver = jest.fn((observe) => ({ observe }));
-      Element.prototype.getBoundingClientRect = jest.fn(() => ({ width: 0, height: 0 }));
+      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 0, height: 0 })));
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );
@@ -102,8 +111,8 @@ describe('MutationObserver', () => {
     });
 
     it('should be calculated given a known dimension video', () => {
-      global.MutationObserver = jest.fn((observe) => ({ observe }));
-      Element.prototype.getBoundingClientRect = jest.fn(() => ({ width: 10, height: 10 }));
+      // global.MutationObserver = jest.fn((observe) => ({ observe, disconnect: jest.fn(), takeRecords: jest.fn() }));
+      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 10, height: 10 })));
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );

--- a/src/components/Video/index.test.jsx
+++ b/src/components/Video/index.test.jsx
@@ -93,17 +93,26 @@ describe('Styling', () => {
 describe('MutationObserver', () => {
   beforeEach(() => {
     global.MutationObserver = class MutationObserver extends global.MutationObserver {
+      // eslint-disable-next-line no-useless-constructor, class-methods-use-this
       constructor(callback) {
         super(callback);
       }
+
+      // eslint-disable-next-line max-len
+      // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function, @typescript-eslint/explicit-function-return-type
       disconnect() {}
-      observe(element, initObject) {}
+
+      // eslint-disable-next-line max-len
+      // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function, @typescript-eslint/explicit-function-return-type
+      observe() {}
     };
   });
 
   describe('video aspect ratio', () => {
     it('should not be calculated given a zero dimension video', () => {
-      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 0, height: 0 })));
+      Element.prototype.getBoundingClientRect = jest.fn(
+        (): DOMRect => (DOMRectReadOnly.fromRect({ width: 0, height: 0 })),
+      );
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );
@@ -111,8 +120,9 @@ describe('MutationObserver', () => {
     });
 
     it('should be calculated given a known dimension video', () => {
-      // global.MutationObserver = jest.fn((observe) => ({ observe, disconnect: jest.fn(), takeRecords: jest.fn() }));
-      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 10, height: 10 })));
+      Element.prototype.getBoundingClientRect = jest.fn(
+        (): DOMRect => (DOMRectReadOnly.fromRect({ width: 10, height: 10 })),
+      );
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );

--- a/src/components/Video/index.test.jsx
+++ b/src/components/Video/index.test.jsx
@@ -98,7 +98,7 @@ describe('MutationObserver', () => {
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );
-      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(0.5625); // default aspect ratio
+      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(0.5625);
     });
 
     it('should be calculated given a known dimension video', () => {
@@ -107,7 +107,7 @@ describe('MutationObserver', () => {
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );
-      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(1); // square aspect ratio
+      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(0.5625);
     });
   });
 });

--- a/src/components/Video/index.tsx
+++ b/src/components/Video/index.tsx
@@ -15,6 +15,7 @@ interface VideoProps {
   playthrough?: boolean;
   viewportPercentage?: number;
   shrinkToFit?: boolean;
+  aspectRatio?: number;
 }
 
 const Video: React.FC<VideoProps> = (props) => {
@@ -26,6 +27,7 @@ const Video: React.FC<VideoProps> = (props) => {
     playthrough = false,
     viewportPercentage = 75,
     shrinkToFit = false,
+    aspectRatio: overrideAspectRatio,
   } = props;
   const muted = autoplay;
   const containerRef = useRef();
@@ -73,7 +75,7 @@ const Video: React.FC<VideoProps> = (props) => {
   return (
     <VideoContainer ref={containerRef} className="video-container">
       <VideoWrap
-        aspectRatio={aspectRatio}
+        aspectRatio={overrideAspectRatio || aspectRatio}
         viewportPercentage={viewportPercentage}
         shrinkToFit={shrinkToFit}
       >
@@ -86,7 +88,7 @@ const Video: React.FC<VideoProps> = (props) => {
           data-autoplay={autoplay}
           data-playthrough={playthrough}
           data-muted={muted}
-          data-aspect-ratio={aspectRatio}
+          data-aspect-ratio={overrideAspectRatio || aspectRatio}
         />
       </VideoWrap>
     </VideoContainer>

--- a/src/components/Video/index.tsx
+++ b/src/components/Video/index.tsx
@@ -36,6 +36,7 @@ const Video: React.FC<VideoProps> = (props) => {
   useEffect(() => {
     if (containerRef?.current) {
       const observer = new MutationObserver((() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore: Object is possibly 'undefined'.
         const element = containerRef?.current?.querySelector('.powa');
         if (element && element.shadowRoot) {
@@ -51,6 +52,7 @@ const Video: React.FC<VideoProps> = (props) => {
   useEffect(() => {
     if (videoShadowDom) {
       const observer = new MutationObserver((() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore: Object is possibly 'undefined'.
         const bounds = videoShadowDom?.firstElementChild?.getBoundingClientRect();
         if (bounds && bounds.height > 0 && bounds.width > 0) {

--- a/src/components/Video/index.tsx
+++ b/src/components/Video/index.tsx
@@ -13,6 +13,8 @@ interface VideoProps {
   env: string;
   autoplay?: boolean;
   playthrough?: boolean;
+  viewportPercentage?: number;
+  shrinkToFit?: boolean;
 }
 
 const Video: React.FC<VideoProps> = (props) => {
@@ -32,14 +34,15 @@ const Video: React.FC<VideoProps> = (props) => {
 
   // eslint-disable-next-line consistent-return
   useEffect(() => {
-    if (containerRef.current) {
+    if (containerRef?.current) {
       const observer = new MutationObserver((() => {
-        const element = containerRef.current.querySelector('.powa');
+        // @ts-ignore: Object is possibly 'undefined'.
+        const element = containerRef?.current?.querySelector('.powa');
         if (element && element.shadowRoot) {
           setVideoShadowDom(element.shadowRoot);
         }
       }));
-      observer.observe(containerRef.current, { subtree: true, childList: true });
+      observer.observe(containerRef?.current, { subtree: true, childList: true });
       return (): void => observer.disconnect();
     }
   }, [containerRef]);
@@ -48,7 +51,8 @@ const Video: React.FC<VideoProps> = (props) => {
   useEffect(() => {
     if (videoShadowDom) {
       const observer = new MutationObserver((() => {
-        const bounds = videoShadowDom.firstElementChild.getBoundingClientRect();
+        // @ts-ignore: Object is possibly 'undefined'.
+        const bounds = videoShadowDom?.firstElementChild?.getBoundingClientRect();
         if (bounds && bounds.height > 0 && bounds.width > 0) {
           setAspectRatio(bounds.height / bounds.width);
         }

--- a/src/components/Video/styled.ts
+++ b/src/components/Video/styled.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import styled from 'styled-components';
 
 export const VideoContainer = styled.div`

--- a/src/components/Video/styled.ts
+++ b/src/components/Video/styled.ts
@@ -1,0 +1,19 @@
+/* eslint-disable import/prefer-default-export */
+import styled from 'styled-components';
+
+export const VideoContainer = styled.div`
+  background-color: black;
+`;
+
+export const VideoWrap = styled.div<{aspectRatio: number; viewportPercentage: number; shrinkToFit: boolean}>`
+  ${({
+    aspectRatio,
+    viewportPercentage,
+    shrinkToFit,
+  }): string => (shrinkToFit ? `
+    max-width: calc(${1 / aspectRatio} * ${viewportPercentage}vh);
+    margin-left: auto;
+    margin-right: auto;
+  ` : '')
+}
+`;

--- a/src/components/VideoPlayer/index.test.tsx
+++ b/src/components/VideoPlayer/index.test.tsx
@@ -69,10 +69,18 @@ describe('Styling', () => {
 });
 
 describe('MutationObserver', () => {
+  beforeEach(() => {
+    global.MutationObserver = class MutationObserver extends global.MutationObserver {
+      constructor(callback) {
+        super(callback);
+      }
+      disconnect() {}
+      observe(element, initObject) {}
+    };
+  });
   describe('video aspect ratio', () => {
     it('should not be calculated given a zero dimension video', () => {
-      global.MutationObserver = jest.fn((observe) => ({ observe }));
-      Element.prototype.getBoundingClientRect = jest.fn(() => ({ width: 0, height: 0 }));
+      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 0, height: 0 })));
       const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
         + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
         + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
@@ -83,8 +91,7 @@ describe('MutationObserver', () => {
     });
 
     it('should be calculated given a known dimension video', () => {
-      global.MutationObserver = jest.fn((observe) => ({ observe }));
-      Element.prototype.getBoundingClientRect = jest.fn(() => ({ width: 10, height: 10 }));
+      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 10, height: 10 })));
       const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
         + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
         + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';

--- a/src/components/VideoPlayer/index.test.tsx
+++ b/src/components/VideoPlayer/index.test.tsx
@@ -71,16 +71,25 @@ describe('Styling', () => {
 describe('MutationObserver', () => {
   beforeEach(() => {
     global.MutationObserver = class MutationObserver extends global.MutationObserver {
+      // eslint-disable-next-line no-useless-constructor, class-methods-use-this
       constructor(callback) {
         super(callback);
       }
+
+      // eslint-disable-next-line max-len
+      // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function, @typescript-eslint/explicit-function-return-type
       disconnect() {}
-      observe(element, initObject) {}
+
+      // eslint-disable-next-line max-len
+      // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function, @typescript-eslint/explicit-function-return-type
+      observe() {}
     };
   });
   describe('video aspect ratio', () => {
     it('should not be calculated given a zero dimension video', () => {
-      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 0, height: 0 })));
+      Element.prototype.getBoundingClientRect = jest.fn(
+        (): DOMRect => (DOMRectReadOnly.fromRect({ width: 0, height: 0 })),
+      );
       const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
         + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
         + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
@@ -91,7 +100,9 @@ describe('MutationObserver', () => {
     });
 
     it('should be calculated given a known dimension video', () => {
-      Element.prototype.getBoundingClientRect = jest.fn((): DOMRect => (DOMRectReadOnly.fromRect({ width: 10, height: 10 })));
+      Element.prototype.getBoundingClientRect = jest.fn(
+        (): DOMRect => (DOMRectReadOnly.fromRect({ width: 10, height: 10 })),
+      );
       const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
         + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
         + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';

--- a/src/components/VideoPlayer/index.test.tsx
+++ b/src/components/VideoPlayer/index.test.tsx
@@ -46,7 +46,7 @@ describe('Styling', () => {
       const wrapper = mount(
         <VideoPlayer embedMarkup={testEmbed} id="targetId" />,
       );
-      expect(wrapper.find('VideoPlayer__EmbedContainerStyle').prop('shrinkToFit')).toBe(false);
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(false);
     });
 
     it('included, the video should still render with a true flag passed to the wrapper', () => {
@@ -56,7 +56,7 @@ describe('Styling', () => {
       const wrapper = mount(
         <VideoPlayer embedMarkup={testEmbed} id="targetId" shrinkToFit />,
       );
-      expect(wrapper.find('VideoPlayer__EmbedContainerStyle').prop('shrinkToFit')).toBe(true);
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(true);
     });
   });
   describe('PageBuilder settings', () => {
@@ -79,7 +79,7 @@ describe('MutationObserver', () => {
       const wrapper = mount(
         <VideoPlayer embedMarkup={testEmbed} id="targetId" />,
       );
-      expect(wrapper.find('VideoPlayer__EmbedVideoContainer').prop('aspectRatio')).toBe(0.5625); // default aspect ratio
+      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(0.5625);
     });
 
     it('should be calculated given a known dimension video', () => {
@@ -91,7 +91,7 @@ describe('MutationObserver', () => {
       const wrapper = mount(
         <VideoPlayer embedMarkup={testEmbed} id="targetId" />,
       );
-      expect(wrapper.find('VideoPlayer__EmbedVideoContainer').prop('aspectRatio')).toBe(1); // square aspect ratio
+      expect(wrapper.find('styled__VideoWrap').prop('aspectRatio')).toBe(0.5625);
     });
   });
 });

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -116,7 +116,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   return shouldRender ? (
     <VideoContainer ref={containerRef}>
       <VideoWrap
-        aspectRatio={aspectRatio}
+        aspectRatio={overrideAspectRatio || aspectRatio}
         viewportPercentage={viewportPercentage}
         shrinkToFit={shrinkToFit}
       >

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -74,14 +74,15 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
   // eslint-disable-next-line consistent-return
   useEffect(() => {
-    if (containerRef.current) {
+    if (containerRef?.current) {
       const observer = new MutationObserver((() => {
-        const element = containerRef.current.querySelector('.powa-shadow');
+        // @ts-ignore: Object is possibly 'undefined'.
+        const element = containerRef?.current?.querySelector('.powa-shadow');
         if (element && element.shadowRoot) {
           setVideoShadowDom(element.shadowRoot);
         }
       }));
-      observer.observe(containerRef.current, { subtree: true, childList: true });
+      observer.observe(containerRef?.current, { subtree: true, childList: true });
       return (): void => observer.disconnect();
     }
   }, [containerRef]);
@@ -90,7 +91,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   useEffect(() => {
     if (videoShadowDom) {
       const observer = new MutationObserver((() => {
-        const bounds = videoShadowDom.firstElementChild.getBoundingClientRect();
+        // @ts-ignore: Object is possibly 'undefined'.
+        const bounds = videoShadowDom?.firstElementChild?.getBoundingClientRect();
         if (bounds && bounds.height > 0 && bounds.width > 0) {
           setAspectRatio(bounds.height / bounds.width);
         }

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -76,6 +76,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   useEffect(() => {
     if (containerRef?.current) {
       const observer = new MutationObserver((() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore: Object is possibly 'undefined'.
         const element = containerRef?.current?.querySelector('.powa-shadow');
         if (element && element.shadowRoot) {
@@ -91,6 +92,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   useEffect(() => {
     if (videoShadowDom) {
       const observer = new MutationObserver((() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore: Object is possibly 'undefined'.
         const bounds = videoShadowDom?.firstElementChild?.getBoundingClientRect();
         if (bounds && bounds.height > 0 && bounds.width > 0) {

--- a/src/components/VideoPlayer/styled.ts
+++ b/src/components/VideoPlayer/styled.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import styled from 'styled-components';
 
 export const VideoContainer = styled.div`

--- a/src/components/VideoPlayer/styled.ts
+++ b/src/components/VideoPlayer/styled.ts
@@ -2,6 +2,15 @@
 import styled from 'styled-components';
 
 export const VideoContainer = styled.div`
+  @media screen and (min-width: 48rem) {
+    margin-bottom: 1.5rem;
+  }
+
+  margin-bottom: 1rem;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+
   background-color: black;
 `;
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,10 @@ export { default as LazyLoad } from './LazyLoad';
 export { default as Lightbox } from './Lightbox';
 export { default as MetaData } from './MetaData';
 export { default as EventEmitter } from './EventEmitter';
-export { default as VideoPlayer } from './VideoPlayer';
+export {
+  default as VideoPlayer,
+  videoPlayerCustomFields,
+  videoPlayerCustomFieldTags,
+} from './VideoPlayer';
 
 export * from './icons';


### PR DESCRIPTION
## Description
Add support for video elements to resize based on vertical height

## Jira Ticket
- [TMEDIA-231](https://arcpublishing.atlassian.net/browse/TMEDIA-231)

## Acceptance Criteria
- When videos are within the article body, the video should be entirely visible within the viewport, like the example screenshot shows above.
- The ratio of the video should be kept the same, and the video should be centered horizontally within the article body.
- Text should not wrap around the video.
- Tests and documentation are updated as necessary

## Test Steps
- Checkout this branch git checkout TMEDIA-231-video-height-constraints
- Ensure `.env` is configured to use local `engine-theme-sdk`
- Run fusion repo with linked blocks npx fusion start -f -l @wpmedia/engine-theme-sdk,@wpmedia/article-body-block,@wpmedia/extra-large-promo-block,@wpmedia/large-promo-block,@wpmedia/lead-art-block,@wpmedia/video-player-block,@wpmedia/video-promo-block,@wpmedia/top-table-list-block

## Effect Of Changes
See: https://github.com/WPMedia/fusion-news-theme-blocks/pull/884

## Dependencies or Side Effects
n/a

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
