### PR TITLE
TMEDIA-35/correct font usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@arc-fusion/prop-types/-/prop-types-0.1.5.tgz",
       "integrity": "sha512-12/1QGXYaGZWDw1vnTX8fltWf3BA7zc95Kn9MyXD/PhFAJBEbpvtD2R+NZ8NU+DMPYlYLP33tyI3NSddERZCAA==",
-      "dev": true,
       "requires": {
         "prop-types": "^15.7.2"
       }

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -27,6 +27,8 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import PropTypes from 'prop-types';
+import getThemeStyle from 'fusion:themes';
+import { useAppContext } from 'fusion:context';
 import Image from '../Image';
 import buildThumborURL from '../Image/thumbor-image-url';
 import Lightbox from '../Lightbox/index';
@@ -413,6 +415,8 @@ const Gallery: React.FC<GalleryProps> = ({
       )),
   };
 
+  const { arcSite } = useAppContext();
+
   return (
     <GalleryDiv
       ref={galleryRef}
@@ -423,24 +427,38 @@ const Gallery: React.FC<GalleryProps> = ({
         <ControlContainer>
           <ControlsButton type="button" onClick={(): void => fullScreen()}>
             <FullscreenIcon fill={greyFill} />
-            <PlaybackText>{expandPhrase || 'Expand'}</PlaybackText>
+            <PlaybackText
+              primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+            >
+              {expandPhrase || 'Expand'}
+            </PlaybackText>
           </ControlsButton>
           <ControlsButton type="button" onClick={(): void => onPlayHandler()}>
             {autoDuration ? (
               <>
                 <PauseIcon fill={greyFill} />
-                <PlaybackText aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}>{pausePhrase || 'Pause autoplay'}</PlaybackText>
+                <PlaybackText
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+                  aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}
+                >
+                  {pausePhrase || 'Pause autoplay'}
+                </PlaybackText>
               </>
             ) : (
               <>
                 <PlayIcon fill={greyFill} />
-                <PlaybackText aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}>{autoplayPhrase || 'Autoplay'}</PlaybackText>
+                <PlaybackText
+                  primaryFont={getThemeStyle(arcSite)['primary-font-family']}
+                  aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}
+                >
+                  {autoplayPhrase || 'Autoplay'}
+                </PlaybackText>
               </>
             )}
           </ControlsButton>
         </ControlContainer>
         <ControlContainer>
-          <ImageCountText dangerouslySetInnerHTML={ImageCountTextOutput} />
+          <ImageCountText primaryFont={getThemeStyle(arcSite)['primary-font-family']} dangerouslySetInnerHTML={ImageCountTextOutput} />
           <ControlsButton type="button" aria-label={previousImagePhrase} onClick={(): void => prevHandler()}>
             <ChevronLeftIcon fill={greyFill} />
           </ControlsButton>

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -57,14 +57,16 @@ export const ControlsButton = styled(GalleryButton as any)`
   }
 `;
 
-export const PlaybackText = styled.span`
+export const PlaybackText = styled.span<{ primaryFont: string }>`
   margin: 0 30px 0 4px;
+  font-family: ${(props): string => props.primaryFont};
 `;
 
-export const ImageCountText = styled.p`
+export const ImageCountText = styled.p<{ primaryFont: string }>`
   display: inline-block;
   margin: 0 0 0 12px;
-
+  font-family: ${(props): string => props.primaryFont};
+  
   span {
     position: absolute !important;
     height: 1px;


### PR DESCRIPTION
## Description
This PR is to correct the font for the Gallery controls.

## Jira Ticket
- [TMEDIA-35](https://arcpublishing.atlassian.net/browse/TMEDIA-35)

## Acceptance Criteria
Fix font for Gallery controls, should be the website PrimaryFont.
Related PR:https://github.com/WPMedia/fusion-news-theme-blocks/pull/890

## Test Steps
1. Checkout this branch `git checkout TMEDIA-35/correct_font_usage`
2. Run `npx fusion start -f -l @wpmedia/shared-styles`
3. Go to http://localhost/pf/all-blocks/?_website=arc-demo-1 and observe the Gallery controls, open the inspector on any of the Gallery elements and the font should be `Work Sans`.

## Effect Of Changes
### Before
<img width="591" alt="Screen Shot 2021-06-03 at 11 57 42 AM" src="https://user-images.githubusercontent.com/82830431/120683253-07681480-c463-11eb-9b2f-9ccaf0875d91.png">

### After
<img width="594" alt="Screen Shot 2021-06-03 at 11 57 03 AM" src="https://user-images.githubusercontent.com/82830431/120683266-0d5df580-c463-11eb-956d-449a9ee102dc.png">


## Dependencies or Side Effects
N/A

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
