### PR TITLE
ci: Add output files for scripts with postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist",
     "types",
-    "svg"
+    "svg",
+    "scripts"
   ],
   "scripts": {
     "build": "rm -rf dist && npm run build:cjs && npm run build:es && npm run build:dts",


### PR DESCRIPTION
- need to read from postinstall script 

```
fusion-verify |     throw new Error(`\`npm install\` process for blocks exited with status code ${status}: ${stderr.toString()}`)
fusion-verify |     ^
fusion-verify | 
fusion-verify | Error: `npm install` process for blocks exited with status code 1: npm WARN deprecated core-js@2.6.12: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
fusion-verify | internal/modules/cjs/loader.js:818
fusion-verify |   throw err;
fusion-verify |   ^
fusion-verify | 
fusion-verify | Error: Cannot find module '/opt/engine/bundle/node_modules/@wpmedia/engine-theme-sdk/scripts/postinstall.js'
fusion-verify |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
fusion-verify |     at Function.Module._load (internal/modules/cjs/loader.js:667:27)
fusion-verify |     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
fusion-verify |     at internal/main/run_main_module.js:17:47 {
fusion-verify |   code: 'MODULE_NOT_FOUND',
fusion-verify |   requireStack: []
fusion-verify | }
fusion-verify | npm ERR! code ELIFECYCLE
fusion-verify | npm ERR! errno 1
fusion-verify | npm ERR! @wpmedia/engine-theme-sdk@2.9.8-canary.4 postinstall: `node scripts/postinstall.js`
fusion-verify | npm ERR! Exit status 1
fusion-verify | npm ERR! 
```