### PR TITLE
Adjust defaults for video scaling

### DIFF
--- a/src/components/Video/index.test.jsx
+++ b/src/components/Video/index.test.jsx
@@ -74,18 +74,18 @@ describe('Styling', () => {
   });
 
   describe('shrinkToFit flag on Video', () => {
-    it('not included, the video should still render with a false flag passed to the wrapper', () => {
+    it('not included, the video should still render with a default true flag passed to the wrapper', () => {
       const wrapper = mount(
         <Video uuid="video-uuid" org="corecomponents" env="prod" />,
       );
-      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(false);
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(true);
     });
 
-    it('included, the video should still render with a true flag passed to the wrapper', () => {
+    it('included, the video should still render with a false flag passed to the wrapper', () => {
       const wrapper = mount(
-        <Video uuid="video-uuid" org="corecomponents" env="prod" shrinkToFit />,
+        <Video uuid="video-uuid" org="corecomponents" env="prod" shrinkToFit={false} />,
       );
-      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(true);
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(false);
     });
   });
 });

--- a/src/components/Video/index.tsx
+++ b/src/components/Video/index.tsx
@@ -25,8 +25,8 @@ const Video: React.FC<VideoProps> = (props) => {
     env,
     autoplay = false,
     playthrough = false,
-    viewportPercentage = 75,
-    shrinkToFit = false,
+    viewportPercentage = 65,
+    shrinkToFit = true,
     aspectRatio: overrideAspectRatio,
   } = props;
   const muted = autoplay;
@@ -109,13 +109,15 @@ Video.propTypes = {
   shrinkToFit: PropTypes.bool.tag({
     name: 'Shrink video to fit screen',
     description: 'Will shrink the video width to keep the video in screen while keeping it horizontally centered to content.',
-    defaultValue: false,
+    defaultValue: true,
+    hidden: true,
     group: 'Video Settings',
   }),
   viewportPercentage: PropTypes.number.tag({
     name: 'Percentage of viewport height',
     description: 'With Shrink Video enabled, this determines how much vertical viewport real estate the video will occupy.',
-    defaultValue: 75,
+    defaultValue: 65,
+    hidden: true,
     group: 'Video Settings',
   }),
 };

--- a/src/components/VideoPlayer/index.test.tsx
+++ b/src/components/VideoPlayer/index.test.tsx
@@ -39,24 +39,24 @@ test('renders embed markup in container', () => {
 
 describe('Styling', () => {
   describe('shrinkToFit flag on Video', () => {
-    it('not included, the video should still render with a false flag passed to the wrapper', () => {
+    it('not included, the video should still render with a default true flag passed to the wrapper', () => {
       const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
         + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
         + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
       const wrapper = mount(
         <VideoPlayer embedMarkup={testEmbed} id="targetId" />,
       );
-      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(false);
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(true);
     });
 
-    it('included, the video should still render with a true flag passed to the wrapper', () => {
+    it('included, the video should still render with a false flag passed to the wrapper', () => {
       const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
         + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
         + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
       const wrapper = mount(
-        <VideoPlayer embedMarkup={testEmbed} id="targetId" shrinkToFit />,
+        <VideoPlayer embedMarkup={testEmbed} id="targetId" shrinkToFit={false} />,
       );
-      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(true);
+      expect(wrapper.find('styled__VideoWrap').prop('shrinkToFit')).toBe(false);
     });
   });
   describe('PageBuilder settings', () => {

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -45,8 +45,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   customFields = {},
   aspectRatio: overrideAspectRatio,
   isPlaythrough = false,
-  shrinkToFit = false,
-  viewportPercentage = 75,
+  shrinkToFit = true,
+  viewportPercentage = 65,
 }) => {
   // migration from video component
   // will fallback to uuid if id is undefined with defaulting to falsy ''
@@ -138,7 +138,7 @@ export const videoPlayerCustomFieldTags = {
     group: 'Video Settings',
     name: 'Shrink video to fit screen',
     description: 'Will shrink the video width to keep the video in screen while keeping it horizontally centered to content.',
-    defaultValue: false,
+    defaultValue: true,
   },
   viewportPercentage: {
     type: PropTypes.number,
@@ -147,19 +147,21 @@ export const videoPlayerCustomFieldTags = {
     description: 'With Shrink Video enabled, this determines how much vertical viewport real estate the video will occupy.',
     min: 0,
     max: 150,
-    defaultValue: 75,
+    defaultValue: 65,
   },
 };
 
 export const videoPlayerCustomFields = (): object => ({
   shrinkToFit: PropTypes.bool.tag({
     ...(videoPlayerCustomFieldTags.shrinkToFit),
-    defaultValue: false,
+    defaultValue: true,
+    hidden: true,
     group: 'Video Settings',
   }),
   viewportPercentage: PropTypes.number.tag({
     ...(videoPlayerCustomFieldTags.viewportPercentage),
-    defaultValue: 75,
+    defaultValue: 65,
+    hidden: true,
     group: 'Video Settings',
   }),
 });


### PR DESCRIPTION
## Description
Updating the default values for video element scaling

## Jira Ticket
- [TMEDIA-231](https://arcpublishing.atlassian.net/browse/TMEDIA-231)

## Acceptance Criteria
- Make the Shrink video to fit screen and Percentage of viewport height Custom Fields be hidden (so behind the scenes they still apply, but PageBuilder Editor users actually can’t see/access/change them) 
--Set the default values of these across all blocks (for both existing blocks on pages, and new blocks added to pages) to: 
--Shrink video to fit screen: true
--Percentage of viewport height: 65

## Test Steps
- View any video block element in the browser and shrink the vertical window until the video scales itself to try to remain at 65% of the vertical height of the window.
Example pages:
/pagebuilder/editor/curate?p=pVn4YlTTErQPvfxgs&v=v5qJSE5KVpQPvfxgs
![image](https://user-images.githubusercontent.com/2287238/120529237-471ef580-c3aa-11eb-80b9-ed562e112441.png)

/pagebuilder/editor/curate?p=p1QhuC8M1z7U89Cgs&v=v57BsowrKn7U89Cgs
![image](https://user-images.githubusercontent.com/2287238/120530332-65392580-c3ab-11eb-921c-9b6321854673.png)


- Video Settings should no longer have settings associated:
![image](https://user-images.githubusercontent.com/2287238/120529173-32426200-c3aa-11eb-9625-0ce4b9a02c3d.png)


## Effect Of Changes
### Before
The Video Settings would allow toggling the ability to scale the video and allow the user to enter a percentage of viewport.

### After
The videos are now defaulted to scale and the settings are no longer visible.

## Dependencies or Side Effects
N/A

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
