### PR TITLE
Update lazy-child to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@arc-fusion/prop-types/-/prop-types-0.1.5.tgz",
       "integrity": "sha512-12/1QGXYaGZWDw1vnTX8fltWf3BA7zc95Kn9MyXD/PhFAJBEbpvtD2R+NZ8NU+DMPYlYLP33tyI3NSddERZCAA==",
-      "dev": true,
       "requires": {
         "prop-types": "^15.7.2"
       }
@@ -10699,6 +10698,14 @@
       "resolved": "https://registry.npmjs.org/dom-parser/-/dom-parser-0.1.6.tgz",
       "integrity": "sha512-3nVRKbLEwmGfghLoeT1dxlK/0votalnOfasP+8VCHYDfDuCETY4LeMblfOeqww6XZk2ymZ1Uewy/hVad6Dy3yw=="
     },
+    "dom-peekaboo": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-peekaboo/-/dom-peekaboo-0.1.0.tgz",
+      "integrity": "sha512-QGfVWlbeTCC+aH0akKbr3NJuaW7i0GRhWaEwsRHz7AeDr5eX3xkjyZBmU86V1lGTjNq4XUxRWWOdk+JOQhMLSQ==",
+      "requires": {
+        "lodash.throttle": "^4.1.1"
+      }
+    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -17406,12 +17413,11 @@
       }
     },
     "lazy-child": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.2.0.tgz",
-      "integrity": "sha512-QOlhECVjMLIS2FNujfZqPXnWBYpd54sv0k4YDgwuPb16CZMMPC5QxNfN/rH0SpfSe3sktK0l6qrOgtScV7eqWQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/lazy-child/-/lazy-child-0.3.1.tgz",
+      "integrity": "sha512-noi341qqpeHJEiGC7YPM+iAhv7HgnrKCWLrsRaM6FX8LKC1g2+iuT4g+hcv3BzYjXotpQjn/Ri/I+Bf68mIONg==",
       "requires": {
-        "@babel/runtime": "^7.0.0",
-        "react-peekaboo": "^0.3.0"
+        "react-peekaboo": "^0.4.1"
       }
     },
     "lazy-universal-dotenv": {
@@ -20307,11 +20313,11 @@
       }
     },
     "react-peekaboo": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.3.0.tgz",
-      "integrity": "sha512-Vae3BZ6aBCqAD4F7nWwX0Q8GWHb15p8hgfLiKtp3XF8/iyWhx+9na4Kz15lvoOR12+V7sdYv3BCNv3rG5gK2uA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-peekaboo/-/react-peekaboo-0.4.1.tgz",
+      "integrity": "sha512-CB/EWYD+3iLKy64HvVC8A0ri/MswbugQZ4QEu48JFbKy8s74L9urfFRBa2CfSpKJVYOy3xbbUR9YSFaa0Vx35w==",
       "requires": {
-        "@babel/runtime": "^7.0.0",
+        "dom-peekaboo": "^0.1.0",
         "lodash.throttle": "^4.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@arc-fusion/prop-types": "^0.1.5",
     "dom-parser": "^0.1.6",
     "is-react": "^1.3.3",
-    "lazy-child": "^0.2.0",
+    "lazy-child": "^0.3.1",
     "polished": "^4.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -140,7 +140,7 @@ const Image: React.FC<ImageProps> = ({
         offsetLeft={lazyOptions.offsetLeft}
         offsetRight={lazyOptions.offsetRight}
         offsetTop={lazyOptions.offsetTop}
-        renderPlaceholder={(ref): React.ReactElement => (
+        renderPlaceholder={(ref: React.Ref<any>): React.ReactElement => (
           <div
             ref={ref}
             style={{ height: mediumHeight, width: mediumWidth, maxWidth: '50px' }}

--- a/src/components/LazyLoad/index.test.tsx
+++ b/src/components/LazyLoad/index.test.tsx
@@ -2,7 +2,6 @@
 import React, { ReactElement } from 'react';
 import { mount } from 'enzyme';
 import LazyLoad from './index';
-import Lazy from 'lazy-child';
 
 const TestComponent = (): ReactElement => (
   <div id="test-component">TEST</div>

--- a/src/components/LazyLoad/index.test.tsx
+++ b/src/components/LazyLoad/index.test.tsx
@@ -2,8 +2,7 @@
 import React, { ReactElement } from 'react';
 import { mount } from 'enzyme';
 import LazyLoad from './index';
-
-jest.mock('lazy-child');
+import Lazy from 'lazy-child';
 
 const TestComponent = (): ReactElement => (
   <div id="test-component">TEST</div>
@@ -18,7 +17,7 @@ describe('LazyLoad Block', () => {
     );
     expect(wrapper).toBeDefined();
     expect(wrapper.prop('enabled')).not.toBeDefined();
-    expect(wrapper.find('Lazy')).toHaveLength(0);
+    expect(wrapper.find('LazyLoad')).toHaveLength(1);
     const testEl = wrapper.find('div#test-component');
     expect(testEl).toHaveLength(1);
     expect(testEl.text()).toEqual('TEST');
@@ -32,7 +31,7 @@ describe('LazyLoad Block', () => {
     );
     expect(wrapper).toBeDefined();
     expect(wrapper.prop('enabled')).toBe(false);
-    expect(wrapper.find('Lazy')).toHaveLength(0);
+    expect(wrapper.find('LazyLoad > TestComponent')).toHaveLength(1);
     const testEl = wrapper.find('div#test-component');
     expect(testEl).toHaveLength(1);
     expect(testEl.text()).toEqual('TEST');
@@ -46,7 +45,7 @@ describe('LazyLoad Block', () => {
     );
     expect(wrapper).toBeDefined();
     expect(wrapper.prop('enabled')).toBe(true);
-    const lazyChildInstance = wrapper.find('Lazy');
+    const lazyChildInstance = wrapper.find('LazyLoad > *:not(TestComponent)');
     expect(lazyChildInstance).toHaveLength(1);
     expect(lazyChildInstance.prop('offsetTop')).toEqual(300);
     expect(lazyChildInstance.prop('offsetBottom')).toEqual(300);
@@ -76,7 +75,7 @@ describe('LazyLoad Block', () => {
     );
     expect(wrapper).toBeDefined();
     expect(wrapper.prop('enabled')).toBe(true);
-    const lazyChildInstance = wrapper.find('Lazy');
+    const lazyChildInstance = wrapper.find('LazyLoad > *:not(TestComponent)');
     expect(lazyChildInstance).toHaveLength(1);
     expect(lazyChildInstance.prop('offsetTop')).toEqual(config.offsetTop);
     expect(lazyChildInstance.prop('offsetBottom')).toEqual(config.offsetBottom);


### PR DESCRIPTION
## Description
Update lazy-child to 0.3.1

## Jira Ticket
- [TMEDIA-247](https://arcpublishing.atlassian.net/browse/TMEDIA-247)

## Acceptance Criteria
1. Use smaller, up-to-date Lazy-Child package in engine theme sdk
2. All blocks using lazy loading should use the SDK (e.g. the Ads Block probably needs to be refactored)
3. Ensure that lazy loading functionality still works as expected across blocks 

## Test Steps
- Ensure Lazy loading is still functioning on the following page by scrolling down and watching the network tab for content loading.
 
## Effect Of Changes
### Before

![image](https://user-images.githubusercontent.com/2287238/120554427-b9520300-c3c7-11eb-917b-12b70927b97a.png)
![image](https://user-images.githubusercontent.com/2287238/120554535-dab2ef00-c3c7-11eb-8f32-e431d4b14511.png)

### After

![image](https://user-images.githubusercontent.com/2287238/120554427-b9520300-c3c7-11eb-917b-12b70927b97a.png)
![image](https://user-images.githubusercontent.com/2287238/120554535-dab2ef00-c3c7-11eb-8f32-e431d4b14511.png)

## Dependencies or Side Effects
This is needed for https://github.com/WPMedia/fusion-news-theme-blocks/pull/894

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
