### PR TITLE
fix: Add fallback logging and stack track

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -44,6 +44,14 @@ try {
   // console.log('installing locally', e);
 }
 
+function unlinkSyncWithErrorLogging(path) {
+  try {
+    fs.unlinkSync(path);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
 // input: themes locale
 // output: timezone-compatible locale
 function mapThemesLocales(themesLocaleString) {
@@ -185,7 +193,7 @@ function outputExportsString(targetFileNamesArray, fileExtension = '') {
 
 // many files have no chance of being picked in blocks.json
 function deleteUnnecessaryFiles() {
-  DELETABLE_FILES.forEach((unnecessaryFileString) => fs.unlinkSync(`${dirPath}${unnecessaryFileString}`));
+  DELETABLE_FILES.forEach((unnecessaryFileString) => unlinkSyncWithErrorLogging(`${dirPath}${unnecessaryFileString}`));
 }
 
 function deleteUnusedFiles() {
@@ -206,7 +214,7 @@ function deleteUnusedFiles() {
         && !TIMEZONE_ALLOW_LIST.includes(fileName)
         && !TIMEZONE_CODES.includes(fileName)
     ) {
-      fs.unlinkSync(`${dirPath}${fileName}`);
+      unlinkSyncWithErrorLogging(`${dirPath}${fileName}`);
     }
   });
 }
@@ -261,7 +269,7 @@ function loopAndSetTimezoneContinents(incomeTargetTimezones) {
 
         if (!targetNestedTimezones.includes(fileNameWithoutExtension) && fileNameWithoutExtension !== 'index') {
           if (fs.lstatSync(targetFilePath).isFile()) {
-            fs.unlinkSync(targetFilePath);
+            unlinkSyncWithErrorLogging(targetFilePath);
           } else {
             rimraf(targetFilePath, (err) => {
               if (err) {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -49,7 +49,7 @@ function unlinkSyncWithErrorLogging(path) {
     fs.unlinkSync(path);
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error(err);
+    console.log(path, 'not deleted');
   }
 }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -48,6 +48,7 @@ function unlinkSyncWithErrorLogging(path) {
   try {
     fs.unlinkSync(path);
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error(err);
   }
 }


### PR DESCRIPTION

test steps: `rm -rf node_modules && npm i && npm i`

- ensure tests still pass and node modules for unused timezone files are deleted 

before: 

- breaks if `rm -rf node_modules && npm i && npm i`

```

fs.js:114
    throw err;
    ^

Error: ENOENT: no such file or directory, unlink '/Users/howardj/sites/engine-theme-sdk/node_modules/timezone/CHANGELOG'
    at Object.unlinkSync (fs.js:951:3)
    at DELETABLE_FILES.forEach (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:188:57)
    at Array.forEach (<anonymous>)
    at deleteUnnecessaryFiles (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:188:19)
    at Object.<anonymous> (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:295:1)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
npm ERR! code 1
npm ERR! path /Users/howardj/sites/engine-theme-sdk
npm ERR! command failed
npm ERR! command sh -c node scripts/postinstall.js
```

after: 

logging: 

```
{ Error: ENOENT: no such file or directory, unlink '/Users/howardj/sites/engine-theme-sdk/node_modules/timezone/zh_TW.js'
    at Object.unlinkSync (fs.js:951:3)
    at unlinkSyncWithErrorLogging (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:49:8)
    at DELETABLE_FILES.forEach (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:196:54)
    at Array.forEach (<anonymous>)
    at deleteUnnecessaryFiles (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:196:19)
    at Object.<anonymous> (/Users/howardj/sites/engine-theme-sdk/scripts/postinstall.js:303:1)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
  errno: -2,
  syscall: 'unlink',
  code: 'ENOENT',
  path:
   '/Users/howardj/sites/engine-theme-sdk/node_modules/timezone/zh_TW.js' }

```

![Screen Shot 2021-06-03 at 14 52 04](https://user-images.githubusercontent.com/5950956/120703654-34c0bc80-c47b-11eb-8bbd-27f0637a856f.png)