### PR TITLE
Refactoring the directory for node_modules and the file path for the blocks.json

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const rimraf = require('rimraf');
+const path = require('path');
 
 // get blocks json allowed strings
 
@@ -33,11 +34,11 @@ const packageName = 'timezone';
 
 // in this case, wherever npm i was called
 // init cwd is the filepath of the initiating command
-const dirPath = `${process.env.INIT_CWD}/node_modules/${packageName}/`;
+const dirPath = `node_modules/${packageName}/`;
 
 try {
   // eslint-disable-next-line global-require,import/no-absolute-path
-  themesLocaleList = require('/opt/engine/bundle/src/blocks.json').localeList;
+  themesLocaleList = require(path.resolve('src/blocks.json')).localeList;
   // console.log('locale list via ./src/blocks.json');
   // console.log(themesLocaleList.toString());
 } catch (e) {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -37,7 +37,7 @@ const packageName = 'timezone';
 const dirPath = `node_modules/${packageName}/`;
 
 try {
-  // eslint-disable-next-line global-require,import/no-absolute-path
+  // eslint-disable-next-line global-require,import/no-absolute-path,import/no-dynamic-require
   themesLocaleList = require(path.resolve('src/blocks.json')).localeList;
   // console.log('locale list via ./src/blocks.json');
   // console.log(themesLocaleList.toString());
@@ -45,12 +45,12 @@ try {
   // console.log('installing locally', e);
 }
 
-function unlinkSyncWithErrorLogging(path) {
+function unlinkSyncWithErrorLogging(targetPath) {
   try {
-    fs.unlinkSync(path);
+    fs.unlinkSync(targetPath);
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log(path, 'not deleted');
+    console.log(targetPath, 'not deleted');
   }
 }
 


### PR DESCRIPTION
## Description
To see the current file structure in the bundle, go to lambda and download the function:
1. https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/fusion-engine-corecomponents/versions/830?tab=code
2. 
![image](https://user-images.githubusercontent.com/24529581/120840870-c3dfda00-c538-11eb-847e-7ef5123b0edf.png)

The compiler has a different path so we need to use relative paths - https://github.com/WPMedia/fusion/blob/927f59d2723551f3f381363ca74ecaae8dd1ef87/compiler/src/compile.js#L63

To test locally, add a blocks.json file in your `src` folder.

## Jira Ticket
- [PEN-](https://arcpublishing.atlassian.net/browse/PEN-)

## Acceptance Criteria
_copy from ticket_

## Test Steps
- Add test steps a reviewer must complete to test this PR

## Effect Of Changes
### Before
_Example: When I clicked the search button, the button turned red._

[include screenshot or gif or link to video, storybook would be awesome]

### After
_Example: When I clicked the search button, the button turned green._

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
