### PR TITLE
Tmedia 234 access timezone nested locales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ storybook-static
 .vscode/*
 /build-storybook.log
 coverage
+src/blocks.json

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,26 +7,9 @@ const rimraf = require('rimraf');
 
 // get blocks json allowed strings
 
-let themesLocaleList = [
-  'en',
-  'sv',
-  'no',
-  'fr',
-  'de',
-  'es',
-  'ja',
-  'ko',
-];
+let themesLocaleList = [];
 
 let targetTimeZones = [
-  'Europe/Paris',
-  'Europe/Oslo',
-  'Europe/Stockholm',
-  'America/New_York',
-  'America/Chicago',
-  'America/Los_Angeles',
-  'America/Mexico_City',
-  'Pacific/Auckland',
 ];
 
 const packageName = 'timezone';
@@ -72,7 +55,31 @@ try {
   themesLocaleList = [...new Set(themesLocaleList)];
   targetTimeZones = [...new Set(targetTimeZones)];
 } catch (err) {
-  // eslint-disable-next-line no-console
+  // set themes locale list default if target blocks.json file not found
+  themesLocaleList = [
+    'en',
+    'sv',
+    'no',
+    'fr',
+    'de',
+    'es',
+    'ja',
+    'ko',
+  ];
+
+  // set timezones default if target blocks.json file not found
+  targetTimeZones = [
+    'Europe/Paris',
+    'Europe/Oslo',
+    'Europe/Stockholm',
+    'America/New_York',
+    'America/Chicago',
+    'America/Los_Angeles',
+    'America/Mexico_City',
+    'Pacific/Auckland',
+  ];
+
+  // if debugging file paths locally this could be helpful
   // console.log(`${process.env.INIT_CWD}/src/blocks.json`, 'not found');
 }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -89,7 +89,13 @@ function unlinkSyncWithErrorLogging(targetPath) {
   try {
     fs.unlinkSync(targetPath);
   } catch (err) {
-    // eslint-disable-next-line no-console
+    // if debugging locally, this logging can be helpful
+    // in the fusion compiler, this logging would not bubble up
+    // as far as I understand, nested dependency postinstall scripts don't log
+    // also interestingly, if you run `rm -rf node_modules && npm i && npm i`
+    // you would see this log because the double install
+    // only installs once but the postinstall script runs twice
+    // https://docs.npmjs.com/cli/v7/using-npm/scripts
     // console.log(targetPath, 'not deleted');
   }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -18,7 +18,7 @@ let themesLocaleList = [
   'ko',
 ];
 
-const targetTimeZones = [
+let targetTimeZones = [
   'Europe/Paris',
   'Europe/Oslo',
   'Europe/Stockholm',
@@ -35,12 +35,45 @@ const packageName = 'timezone';
 // init cwd is the filepath of the initiating command
 const dirPath = `${process.env.INIT_CWD}/node_modules/${packageName}/`;
 
+let targetBlockValues = {};
 try {
   // eslint-disable-next-line global-require,import/no-dynamic-require
-  themesLocaleList = require(`${process.env.INIT_CWD}/src/blocks.json`).localeList;
+  targetBlockValues = require(`${process.env.INIT_CWD}/src/blocks.json`).values;
+
+  const defaultLocalizationObject = targetBlockValues.default.siteProperties.dateLocalization;
+
+  // must have a default language and timezone
+  // redefining locale list over the defaults
+  themesLocaleList = [defaultLocalizationObject.language];
+  targetTimeZones = [defaultLocalizationObject.timeZone];
+  /*
+    "sites": {
+      "arc-demo-1": {
+      "siteProperties": {
+        "dateLocalization": {
+          "language": "es",
+          "timeZone": "Europe/Madrid"
+        },
+      }
+    }
+  */
+
+  // if sites
+  // obj with key is truthy if sites property exists
+  Object.values(targetBlockValues.sites).forEach(({ siteProperties: sitePropertyObject }) => {
+    // if site has no date localization obj
+    if (sitePropertyObject.dateLocalization) {
+      themesLocaleList.push(sitePropertyObject.dateLocalization.language);
+      targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
+    }
+  });
+
+  // dedupe languages and timezones if any added
+  themesLocaleList = [...new Set(themesLocaleList)];
+  targetTimeZones = [...new Set(targetTimeZones)];
 } catch (err) {
   // eslint-disable-next-line no-console
-  console.log(`${process.env.INIT_CWD}/src/blocks.json`, 'not found');
+  // console.log(`${process.env.INIT_CWD}/src/blocks.json`, 'not found');
 }
 
 function unlinkSyncWithErrorLogging(targetPath) {
@@ -48,7 +81,7 @@ function unlinkSyncWithErrorLogging(targetPath) {
     fs.unlinkSync(targetPath);
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log(targetPath, 'not deleted');
+    // console.log(targetPath, 'not deleted');
   }
 }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -80,6 +80,8 @@ try {
   ];
 
   // if debugging file paths locally this could be helpful
+  // nested dependency postinstall logging doesn't bubble up sadly in compiler
+  // installed here https://github.com/WPMedia/fusion/blob/927f59d2723551f3f381363ca74ecaae8dd1ef87/compiler/src/compile.js#L63
   // console.log(`${process.env.INIT_CWD}/src/blocks.json`, 'not found');
 }
 


### PR DESCRIPTION
## Description
Take in blocks.json dateLocalization values from sites. Change path based on investigation into fusion https://github.com/WPMedia/fusion/blob/927f59d2723551f3f381363ca74ecaae8dd1ef87/compiler/src/compile.js#L63

## Jira Ticket
- [TMEDIA-234](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-234&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- Take in timezones and languages only from dateLocalizations obj. no hard-coded includes
- Allows for IANA database timezone specified included only

## Test Steps
- add mock `src/blocks.json`  to simulate the behavior with what's working now. (example of blocks.json here https://github.com/WPMedia/Fusion-News-Theme/blob/master/blocks.json) can change timeZone via: 

```
        "dateLocalization": {
          "language": "en",
          "timeZone": "America/New_York", 
          "dateTimeFormat": "%B %d, %Y at %l:%M %P %Z",
          "dateFormat": "%B %d, %Y"
        },

        "dateLocalization": {
          "language": "en",
          "timeZone": "America/Belize", 
          "dateTimeFormat": "%B %d, %Y at %l:%M %P %Z",
          "dateFormat": "%B %d, %Y"
        },
```


- I tested having no language within the dateLocalization object
- Ensuring duplicate timezones and date localization languages 
- Add `src/blocks.json` to test postinstall script within themes production src
- `rm -rf node_modules && npm i && ls node_modules/timezone` to see effect 
- Should see effect of siteproperties -> sitename -> dateLocalization -> timezone and language 
- Pick timezones based on IANA Timezone Database. Only get the timezones that are specified. Allows for extendability and minimal depedencies

## Effect Of Changes
### Before
- All possible 6 timezones and date languages included for all clients
- Clients could not use unapproved timezones 

### After
- Only required timezones and date languages included in bundle
- Clients can use any timezone
- poc for including blocks.json dynamically in postinstall is available at deployment 840. Only including locale American English. In this pr, we're using the correct date localization object now in the sites

## Dependencies or Side Effects
- None

deferred: 
- This does not allow new languages outside of the allowed currently list

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [] Confirmed this PR has unit test files -> na
  - [ ] Ran `npm test`, made sure all tests are passing -> na
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added. -> already written

