### PR TITLE
TMEDIA-35/new prop for Gallery, passed from fusion blocks

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -104,6 +104,7 @@ interface GalleryProps {
   adElement?: Function;
   previousImagePhrase?: string;
   nextImagePhrase?: string;
+  primaryFont?: string;
 }
 
 declare interface EventOptionsInterface {
@@ -124,6 +125,7 @@ const Gallery: React.FC<GalleryProps> = ({
   adElement: AdElement,
   previousImagePhrase = PREVIOUS_IMAGE_TEXT,
   nextImagePhrase = NEXT_IMAGE_TEXT,
+  primaryFont = 'NEXT_IMAGE_TEXT',
 }) => {
   const galleryRef = useRef(null);
   const carouselRef = useRef(null);
@@ -423,24 +425,24 @@ const Gallery: React.FC<GalleryProps> = ({
         <ControlContainer>
           <ControlsButton type="button" onClick={(): void => fullScreen()}>
             <FullscreenIcon fill={greyFill} />
-            <PlaybackText>{expandPhrase || 'Expand'}</PlaybackText>
+            <PlaybackText primaryFont={primaryFont}>{expandPhrase || 'Expand'}</PlaybackText>
           </ControlsButton>
           <ControlsButton type="button" onClick={(): void => onPlayHandler()}>
             {autoDuration ? (
               <>
                 <PauseIcon fill={greyFill} />
-                <PlaybackText aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}>{pausePhrase || 'Pause autoplay'}</PlaybackText>
+                <PlaybackText primaryFont={primaryFont} aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}>{pausePhrase || 'Pause autoplay'}</PlaybackText>
               </>
             ) : (
               <>
                 <PlayIcon fill={greyFill} />
-                <PlaybackText aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}>{autoplayPhrase || 'Autoplay'}</PlaybackText>
+                <PlaybackText primaryFont={primaryFont} aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}>{autoplayPhrase || 'Autoplay'}</PlaybackText>
               </>
             )}
           </ControlsButton>
         </ControlContainer>
         <ControlContainer>
-          <ImageCountText dangerouslySetInnerHTML={ImageCountTextOutput} />
+          <ImageCountText primaryFont={primaryFont} dangerouslySetInnerHTML={ImageCountTextOutput} />
           <ControlsButton type="button" aria-label={previousImagePhrase} onClick={(): void => prevHandler()}>
             <ChevronLeftIcon fill={greyFill} />
           </ControlsButton>
@@ -527,6 +529,8 @@ Gallery.propTypes = {
   interstitialClicks: PropTypes.number,
   /** Function element to be rendered as an Ad */
   adElement: PropTypes.func,
+  /** Primary Font */
+  primaryFont: PropTypes.string,
 };
 
 export default Gallery;

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -104,7 +104,7 @@ interface GalleryProps {
   adElement?: Function;
   previousImagePhrase?: string;
   nextImagePhrase?: string;
-  primaryFont?: string;
+  controlsFont?: string;
 }
 
 declare interface EventOptionsInterface {
@@ -125,7 +125,7 @@ const Gallery: React.FC<GalleryProps> = ({
   adElement: AdElement,
   previousImagePhrase = PREVIOUS_IMAGE_TEXT,
   nextImagePhrase = NEXT_IMAGE_TEXT,
-  primaryFont = null,
+  controlsFont = null,
 }) => {
   const galleryRef = useRef(null);
   const carouselRef = useRef(null);
@@ -425,14 +425,14 @@ const Gallery: React.FC<GalleryProps> = ({
         <ControlContainer>
           <ControlsButton type="button" onClick={(): void => fullScreen()}>
             <FullscreenIcon fill={greyFill} />
-            <PlaybackText primaryFont={primaryFont}>{expandPhrase || 'Expand'}</PlaybackText>
+            <PlaybackText primaryFont={controlsFont}>{expandPhrase || 'Expand'}</PlaybackText>
           </ControlsButton>
           <ControlsButton type="button" onClick={(): void => onPlayHandler()}>
             {autoDuration ? (
               <>
                 <PauseIcon fill={greyFill} />
                 <PlaybackText
-                  primaryFont={primaryFont}
+                  primaryFont={controlsFont}
                   aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}
                 >
                   {pausePhrase || 'Pause autoplay'}
@@ -442,7 +442,7 @@ const Gallery: React.FC<GalleryProps> = ({
               <>
                 <PlayIcon fill={greyFill} />
                 <PlaybackText
-                  primaryFont={primaryFont}
+                  primaryFont={controlsFont}
                   aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}
                 >
                   {autoplayPhrase || 'Autoplay'}
@@ -453,7 +453,7 @@ const Gallery: React.FC<GalleryProps> = ({
         </ControlContainer>
         <ControlContainer>
           <ImageCountText
-            primaryFont={primaryFont}
+            primaryFont={controlsFont}
             dangerouslySetInnerHTML={ImageCountTextOutput}
           />
           <ControlsButton type="button" aria-label={previousImagePhrase} onClick={(): void => prevHandler()}>
@@ -543,7 +543,7 @@ Gallery.propTypes = {
   /** Function element to be rendered as an Ad */
   adElement: PropTypes.func,
   /** Primary Font */
-  primaryFont: PropTypes.string,
+  controlsFont: PropTypes.string,
 };
 
 export default Gallery;

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -431,12 +431,22 @@ const Gallery: React.FC<GalleryProps> = ({
             {autoDuration ? (
               <>
                 <PauseIcon fill={greyFill} />
-                <PlaybackText primaryFont={primaryFont} aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}>{pausePhrase || 'Pause autoplay'}</PlaybackText>
+                <PlaybackText
+                  primaryFont={primaryFont}
+                  aria-label={autoplayPhraseLabels.stop || 'Stop automatic slide show'}
+                >
+                  {pausePhrase || 'Pause autoplay'}
+                </PlaybackText>
               </>
             ) : (
               <>
                 <PlayIcon fill={greyFill} />
-                <PlaybackText primaryFont={primaryFont} aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}>{autoplayPhrase || 'Autoplay'}</PlaybackText>
+                <PlaybackText
+                  primaryFont={primaryFont}
+                  aria-label={autoplayPhraseLabels.start || 'Start automatic slide show'}
+                >
+                  {autoplayPhrase || 'Autoplay'}
+                </PlaybackText>
               </>
             )}
           </ControlsButton>

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -125,7 +125,7 @@ const Gallery: React.FC<GalleryProps> = ({
   adElement: AdElement,
   previousImagePhrase = PREVIOUS_IMAGE_TEXT,
   nextImagePhrase = NEXT_IMAGE_TEXT,
-  primaryFont = 'NEXT_IMAGE_TEXT',
+  primaryFont = null,
 }) => {
   const galleryRef = useRef(null);
   const carouselRef = useRef(null);

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -452,7 +452,10 @@ const Gallery: React.FC<GalleryProps> = ({
           </ControlsButton>
         </ControlContainer>
         <ControlContainer>
-          <ImageCountText primaryFont={primaryFont} dangerouslySetInnerHTML={ImageCountTextOutput} />
+          <ImageCountText
+            primaryFont={primaryFont}
+            dangerouslySetInnerHTML={ImageCountTextOutput}
+          />
           <ControlsButton type="button" aria-label={previousImagePhrase} onClick={(): void => prevHandler()}>
             <ChevronLeftIcon fill={greyFill} />
           </ControlsButton>

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -57,11 +57,13 @@ export const ControlsButton = styled(GalleryButton as any)`
   }
 `;
 
-export const PlaybackText = styled.span`
+export const PlaybackText = styled.span<{ primaryFont: string }>`
+  font-family: ${(props): string => props.primaryFont};
   margin: 0 30px 0 4px;
 `;
 
-export const ImageCountText = styled.p`
+export const ImageCountText = styled.p<{ primaryFont: string }>`
+  font-family: ${(props): string => props.primaryFont};
   display: inline-block;
   margin: 0 0 0 12px;
 


### PR DESCRIPTION
## Description
This PR is to correct the font for the Gallery controls.
**NOTE**: must be on branch `TMEDIA-35/correct_font_usage` in https://github.com/WPMedia/fusion-news-theme-blocks to test this correctly since they work together for this particular solution

## Jira Ticket
- [TMEDIA-35](https://arcpublishing.atlassian.net/browse/TMEDIA-35)

## Acceptance Criteria
Fix font for Gallery controls, should be the website PrimaryFont.
Related PR:https://github.com/WPMedia/fusion-news-theme-blocks/pull/890

## Test Steps
1. Checkout this branch `git checkout TMEDIA-35/correct_font_usage`
2. Run `npx fusion start -f -l @wpmedia/shared-styles`
3. Go to http://localhost/pf/all-blocks/?_website=arc-demo-1 and observe the Gallery controls, open the inspector on any of the Gallery elements and the font should be `Work Sans`.

## Effect Of Changes
### Before
<img width="591" alt="Screen Shot 2021-06-03 at 11 57 42 AM" src="https://user-images.githubusercontent.com/82830431/120683253-07681480-c463-11eb-9b2f-9ccaf0875d91.png">

### After
<img width="594" alt="Screen Shot 2021-06-03 at 11 57 03 AM" src="https://user-images.githubusercontent.com/82830431/120683266-0d5df580-c463-11eb-956d-449a9ee102dc.png">


## Dependencies or Side Effects
N/A

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
