### PR TITLE
tmedia-226: Remove important tag for span accessibility in gallery

### DIFF
--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -68,7 +68,7 @@ export const ImageCountText = styled.p<{ primaryFont: string }>`
   margin: 0 0 0 12px;
 
   span {
-    position: absolute !important;
+    position: absolute;
     height: 1px;
     width: 1px;
     overflow: hidden;


### PR DESCRIPTION
## Description
_Information about what you changed for this PR_

## Jira Ticket
- [TMEDIA-226](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-266&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
- No !important usage
- Functionality of accessibility ticket as before 

## Test Steps

via https://github.com/WPMedia/engine-theme-sdk/pull/330 (3)

Testing "Image X of X" is read correctly

Open storybook - http://localhost:6006/?path=/story/gallery--custom-gallery
Using your keyboard arrow keys navigate to the text that shows on the screen as 1 of 9
When on text using the VoiceOver keyboard shortcut - VO+S - VO stands for VoiceOver modifier key

https://user-images.githubusercontent.com/5950956/122276793-c3393300-ceaa-11eb-9253-134df637bfda.mov

## Effect Of Changes
### Before
- Amp validation would fail because of !important usage

### After
- Amp validation may pass without this usage of !important 

## Dependencies or Side Effects
- No change 
- Look of gallery is unchanged locally linking engine-theme-sdk

before 
https://corecomponents.arcpublishing.com/pf/all-blocks/?_website=the-gazette

![Screen Shot 2021-06-16 at 14 02 35](https://user-images.githubusercontent.com/5950956/122277556-a2bda880-ceab-11eb-8b47-bef416bbc8a0.png)
http://localhost/pf/all-blocks/?_website=the-gazette

after 
http://localhost/pf/all-blocks/?_website=the-gazette
<img width="441" alt="Screen Shot 2021-06-16 at 14 02 25" src="https://user-images.githubusercontent.com/5950956/122277543-9df8f480-ceab-11eb-975e-18480a807020.png">

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage -> na
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
