### PR TITLE
fix: Use http for content protocol replacement

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -90,7 +90,9 @@ const Image: React.FC<ImageProps> = ({
     return null;
   }
 
-  const imageSourceWithoutProtocol = url.replace('https://', '');
+  const imageSourceWithoutProtocol = url
+    .replace('https://', '')
+    .replace('http://', '');
 
   const {
     // breakpoints default to mobile, tablet, larger screen

--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -670,3 +670,36 @@ For more information on how to setup resizedImageOptions, please see: [Secure Im
     />
   </Story>
 </Canvas>
+
+### **For http images**
+
+<Canvas>
+  <Story name="For http images">
+    <Image
+      url={
+        "http://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/XEVN7EOCEZBN5GOPBWQ5NPSW64.JPG"
+      }
+      alt={"brand image"}
+      smallWidth={274}
+      smallHeight={154}
+      mediumWidth={274}
+      mediumHeight={154}
+      largeWidth={274}
+      largeHeight={154}
+      resizedImageOptions={{
+        "274x154": "NnxQC4v8GO_BAbDNdty3Kdb7XtA=filters:format(jpg):quality(70)/",
+      }}
+      resizerURL={
+        "https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer"
+      }
+      breakpoints={{
+        small: 420,
+        medium: 768,
+        large: 992,
+      }}
+      lightBoxWidth={274}
+      lightBoxHeight={154}
+      compressedThumborParams={false}
+    />
+  </Story>
+</Canvas>


### PR DESCRIPTION
- see blocks test instructions https://github.com/WPMedia/fusion-news-theme-blocks/pull/910


-> can see this in storybook as well `npm run storybook` 

<img width="576" alt="Screen Shot 2021-06-16 at 15 36 34" src="https://user-images.githubusercontent.com/5950956/122289780-b3285000-ceb8-11eb-82f7-e018104d0337.png">
