### PR TITLE
TMEDIA 288 - Fix layout reflow in card list and elsewhere

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -383,6 +383,13 @@ const Gallery: React.FC<GalleryProps> = ({
         resizedImageOptions={imgContent.resized_params}
         breakpoints={imgContent.breakpoints || {}}
         resizerURL={resizerURL}
+        // keep lazy options for intersection observer wrapper
+        lazyOptions={{
+          offsetBottom: 0,
+          offsetTop: 0,
+          offsetRight: 0,
+          offsetLeft: 0,
+        }}
       />
     </ImageWrapper>
   );

--- a/src/components/Image/image.test.jsx
+++ b/src/components/Image/image.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import Image from './index';
 
@@ -48,7 +48,7 @@ describe('image component', () => {
     expect(altProperty).toBe(alt);
   });
   it('returns various breakpoints with the widths', () => {
-    const wrapper = shallow(<Image
+    const wrapper = mount(<Image
       url={rawURL}
       alt={alt}
       smallWidth={smallWidth}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -176,7 +176,6 @@ const Image: React.FC<ImageProps> = ({
               data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
               width={largeWidth}
               height={largeHeight}
-              loading="lazy"
             />
           )
         }

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 /* eslint-disable no-console */
 import React from 'react';
 import styled from 'styled-components';
@@ -131,25 +132,6 @@ const Image: React.FC<ImageProps> = ({
     );
   }
 
-  const FallbackImages: React.FunctionComponent<{}> = () => (
-    resizedImageOptions ? (
-      <img
-        alt={alt}
-        src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
-        width={largeWidth}
-        height={largeHeight}
-      />
-    ) : (
-      <img
-        alt={alt}
-        src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
-        width={largeWidth}
-        height={largeHeight}
-        loading="lazy"
-      />
-    )
-  );
-
   const ImageSources: React.FunctionComponent<{}> = () => (
     <>
       <SourceHandler
@@ -179,7 +161,22 @@ const Image: React.FC<ImageProps> = ({
       {
         typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
           ? (
-            <FallbackImages />
+            resizedImageOptions ? (
+              <img
+                alt={alt}
+                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+                width={largeWidth}
+                height={largeHeight}
+              />
+            ) : (
+              <img
+                alt={alt}
+                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+                width={largeWidth}
+                height={largeHeight}
+                loading="lazy"
+              />
+            )
           )
           : (
             <img

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -6,6 +6,8 @@ import Lazy from 'lazy-child';
 import buildThumborURL from './thumbor-image-url';
 import SourceHandler from './SourceHandler';
 
+const LAZY_OPTIONS_DEFAULT = false;
+
 interface LazyProps {
   offsetBottom?: number;
   offsetLeft?: number;
@@ -79,12 +81,7 @@ const Image: React.FC<ImageProps> = ({
   breakpoints,
   lightBoxWidth,
   lightBoxHeight,
-  lazyOptions = {
-    offsetBottom: 0,
-    offsetLeft: 0,
-    offsetRight: 0,
-    offsetTop: 0,
-  },
+  lazyOptions,
 }) => {
   if (typeof url === 'undefined') {
     return null;
@@ -135,66 +132,82 @@ const Image: React.FC<ImageProps> = ({
     );
   }
 
+  const ImageSources: React.FunctionComponent<{}> = () => (
+    <>
+      <SourceHandler
+        resizedImageOptions={resizedImageOptions}
+        width={largeWidth}
+        height={largeHeight}
+        imageSourceWithoutProtocol={imageSourceWithoutProtocol}
+        resizerURL={resizerURL}
+        breakpointWidth={largeBreakpoint}
+      />
+      <SourceHandler
+        resizedImageOptions={resizedImageOptions}
+        width={mediumWidth}
+        height={mediumHeight}
+        imageSourceWithoutProtocol={imageSourceWithoutProtocol}
+        resizerURL={resizerURL}
+        breakpointWidth={mediumBreakpoint}
+      />
+      <SourceHandler
+        resizedImageOptions={resizedImageOptions}
+        width={smallWidth}
+        height={smallHeight}
+        imageSourceWithoutProtocol={imageSourceWithoutProtocol}
+        resizerURL={resizerURL}
+        breakpointWidth={smallBreakpoint}
+      />
+      {
+        typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
+          ? (
+            <img
+              alt={alt}
+              src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+              width={largeWidth}
+              height={largeHeight}
+              loading="lazy"
+            />
+          )
+          : (
+            <img
+              alt={alt}
+              src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+              // lightbox component reads from this data attribute
+              data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
+              width={largeWidth}
+              height={largeHeight}
+              loading="lazy"
+            />
+          )
+        }
+    </>
+  );
+
+  if (lazyOptions) {
+    return (
+      <StyledPicture>
+        <Lazy
+          offsetBottom={lazyOptions.offsetBottom}
+          offsetLeft={lazyOptions.offsetLeft}
+          offsetRight={lazyOptions.offsetRight}
+          offsetTop={lazyOptions.offsetTop}
+          renderPlaceholder={(ref: React.Ref<any>): React.ReactElement => (
+            <div
+              ref={ref}
+              style={{ height: mediumHeight, width: mediumWidth, maxWidth: '50px' }}
+            />
+          )}
+        >
+          <ImageSources />
+        </Lazy>
+      </StyledPicture>
+    );
+  }
+
   return (
     <StyledPicture>
-      <Lazy
-        offsetBottom={lazyOptions.offsetBottom}
-        offsetLeft={lazyOptions.offsetLeft}
-        offsetRight={lazyOptions.offsetRight}
-        offsetTop={lazyOptions.offsetTop}
-        renderPlaceholder={(ref: React.Ref<any>): React.ReactElement => (
-          <div
-            ref={ref}
-            style={{ height: mediumHeight, width: mediumWidth, maxWidth: '50px' }}
-          />
-        )}
-      >
-        <SourceHandler
-          resizedImageOptions={resizedImageOptions}
-          width={largeWidth}
-          height={largeHeight}
-          imageSourceWithoutProtocol={imageSourceWithoutProtocol}
-          resizerURL={resizerURL}
-          breakpointWidth={largeBreakpoint}
-        />
-        <SourceHandler
-          resizedImageOptions={resizedImageOptions}
-          width={mediumWidth}
-          height={mediumHeight}
-          imageSourceWithoutProtocol={imageSourceWithoutProtocol}
-          resizerURL={resizerURL}
-          breakpointWidth={mediumBreakpoint}
-        />
-        <SourceHandler
-          resizedImageOptions={resizedImageOptions}
-          width={smallWidth}
-          height={smallHeight}
-          imageSourceWithoutProtocol={imageSourceWithoutProtocol}
-          resizerURL={resizerURL}
-          breakpointWidth={smallBreakpoint}
-        />
-        {
-          typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
-            ? (
-              <img
-                alt={alt}
-                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
-                width={largeWidth}
-                height={largeHeight}
-              />
-            )
-            : (
-              <img
-                alt={alt}
-                src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
-                // lightbox component reads from this data attribute
-                data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
-                width={largeWidth}
-                height={largeHeight}
-              />
-            )
-        }
-      </Lazy>
+      <ImageSources />
     </StyledPicture>
   );
 };

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -186,7 +186,6 @@ const Image: React.FC<ImageProps> = ({
               data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
               width={largeWidth}
               height={largeHeight}
-              // lightbox lazy not an option
             />
           )
         }

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -131,6 +131,25 @@ const Image: React.FC<ImageProps> = ({
     );
   }
 
+  const FallbackImages: React.FunctionComponent<{}> = () => (
+    resizedImageOptions ? (
+      <img
+        alt={alt}
+        src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+        width={largeWidth}
+        height={largeHeight}
+      />
+    ) : (
+      <img
+        alt={alt}
+        src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
+        width={largeWidth}
+        height={largeHeight}
+        loading="lazy"
+      />
+    )
+  );
+
   const ImageSources: React.FunctionComponent<{}> = () => (
     <>
       <SourceHandler
@@ -160,14 +179,7 @@ const Image: React.FC<ImageProps> = ({
       {
         typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
           ? (
-            <img
-              alt={alt}
-              src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
-              width={largeWidth}
-              height={largeHeight}
-              // todo: opt out of lazy for previous same functionality
-              loading="lazy"
-            />
+            <FallbackImages />
           )
           : (
             <img

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -161,6 +161,10 @@ const Image: React.FC<ImageProps> = ({
       {
         typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
           ? (
+            /*
+              if there's options, not null or undefined,
+              we're using intersection observer not loading="lazy"
+            */
             lazyOptions ? (
               <img
                 alt={alt}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -6,8 +6,6 @@ import Lazy from 'lazy-child';
 import buildThumborURL from './thumbor-image-url';
 import SourceHandler from './SourceHandler';
 
-const LAZY_OPTIONS_DEFAULT = false;
-
 interface LazyProps {
   offsetBottom?: number;
   offsetLeft?: number;
@@ -111,6 +109,7 @@ const Image: React.FC<ImageProps> = ({
           // for fallback width and height
           width={largeWidth}
           height={largeHeight}
+          loading="lazy"
         />
       </StyledPicture>
     );

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -161,7 +161,7 @@ const Image: React.FC<ImageProps> = ({
       {
         typeof lightBoxWidth === 'undefined' || typeof lightBoxHeight === 'undefined'
           ? (
-            resizedImageOptions ? (
+            lazyOptions ? (
               <img
                 alt={alt}
                 src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -165,6 +165,7 @@ const Image: React.FC<ImageProps> = ({
               src={buildThumborURL(resizedImageOptions[`${largeWidth}x${largeHeight}`], `${largeWidth}x${largeHeight}`, imageSourceWithoutProtocol, resizerURL)}
               width={largeWidth}
               height={largeHeight}
+              // todo: opt out of lazy for previous same functionality
               loading="lazy"
             />
           )
@@ -176,6 +177,7 @@ const Image: React.FC<ImageProps> = ({
               data-lightbox={buildThumborURL(resizedImageOptions[`${lightBoxWidth}x${lightBoxHeight}`], `${lightBoxWidth}x${lightBoxHeight}`, imageSourceWithoutProtocol, resizerURL)}
               width={largeWidth}
               height={largeHeight}
+              // lightbox lazy not an option
             />
           )
         }

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1675,8 +1675,6 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
               key={imageSrc + keyEndings[srcType]}
               alt={typeof imageTitle === 'string' ? imageTitle : translate('Image')}
               draggable={false}
-              // lazy would go here, but can't validate
-              // loading="lazy"
             />,
           );
         }

--- a/src/components/Lightbox/lightbox-react.tsx
+++ b/src/components/Lightbox/lightbox-react.tsx
@@ -1675,6 +1675,8 @@ class ReactImageLightbox extends Component<LightboxProps, LightboxState> {
               key={imageSrc + keyEndings[srcType]}
               alt={typeof imageTitle === 'string' ? imageTitle : translate('Image')}
               draggable={false}
+              // lazy would go here, but can't validate
+              // loading="lazy"
             />,
           );
         }

--- a/stories/Image.stories.mdx
+++ b/stories/Image.stories.mdx
@@ -173,6 +173,12 @@ For more information on how to setup resizedImageOptions, please see: [Secure Im
           medium: 768,
           large: 992,
         }}
+        lazyOptions={{
+          offsetBottom: 0,
+          offsetTop: 0,
+          offsetRight: 0,
+          offsetLeft: 0
+        }}
       />
       <p style={{ height: "150vh" }}></p>
       <Image
@@ -197,6 +203,12 @@ For more information on how to setup resizedImageOptions, please see: [Secure Im
           small: 420,
           medium: 768,
           large: 992,
+        }}
+        lazyOptions={{
+          offsetBottom: 0,
+          offsetTop: 0,
+          offsetRight: 0,
+          offsetLeft: 0
         }}
       />
       <p style={{ height: "150vh" }}></p>
@@ -224,6 +236,12 @@ For more information on how to setup resizedImageOptions, please see: [Secure Im
           small: 420,
           medium: 768,
           large: 992,
+        }}
+        lazyOptions={{
+          offsetBottom: 0,
+          offsetTop: 0,
+          offsetRight: 0,
+          offsetLeft: 0
         }}
       />
     </div>


### PR DESCRIPTION
test: see https://github.com/WPMedia/fusion-news-theme-blocks/pull/930

see comments for perf improvements https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-288

before: 

- cumulative layout shift and jumpy images on scroll due to intersection observer 

after:

- non-breaking change that clients will be able to still use intersection observer image if they've coded that into custom blocks
- themes blocks will use loading lazy to dynamically load based off of connection speed and viewport 

resources: 

https://web.dev/browser-level-image-lazy-loading/