### PR TITLE
TMEDIA-290/Rendering HTML in image subtitles

### DIFF
--- a/src/components/ImageMetadata/index.test.tsx
+++ b/src/components/ImageMetadata/index.test.tsx
@@ -34,14 +34,14 @@ describe('the ImageMetadata component', () => {
         caption="aaaaaa"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span').hasClass('title')).toBe(false);
       expect(wrapper.text()).toBe('aaaaaa (bbbyyy/affff)');
     });
   });
 
   describe('when no caption is passed in the props', () => {
     it('should not include the caption text', () => {
-      const wrapper = mount(<ImageMetadata
+      const wrapper = shallow(<ImageMetadata
         subtitle="ffffg"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
       />);

--- a/src/components/ImageMetadata/index.test.tsx
+++ b/src/components/ImageMetadata/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ImageMetadata from '.';
 
 jest.mock('fusion:themes', () => (): object => ({
@@ -30,18 +30,18 @@ describe('the ImageMetadata component', () => {
 
   describe('when no subtitle is passed in the props', () => {
     it('should not include the subtitle span', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         caption="aaaaaa"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(0);
+      expect(wrapper.find('span')).toHaveLength(1);
       expect(wrapper.text()).toBe('aaaaaa (bbbyyy/affff)');
     });
   });
 
   describe('when no caption is passed in the props', () => {
     it('should not include the caption text', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
       />);
@@ -53,11 +53,11 @@ describe('the ImageMetadata component', () => {
 
   describe('when no credits are passed in the props', () => {
     it('should not include the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu ');
     });
@@ -65,12 +65,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when no byline is passed in the props', () => {
     it('should not include the byline in the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ affiliation: [{ name: 'affff' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (affff)');
     });
@@ -78,12 +78,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when an empty byline is passed in the props', () => {
     it('should not include the byline in the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [], affiliation: [{ name: 'affff' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (affff)');
     });
@@ -91,12 +91,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when a nameless byline is passed in the props', () => {
     it('should not include the byline in the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{}], affiliation: [{ name: 'affff' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (affff)');
     });
@@ -104,12 +104,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when no affiliation is passed in the props', () => {
     it('should not include the affliation in the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (bbbyyy)');
     });
@@ -117,12 +117,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when an empty affiliation is passed in the props', () => {
     it('should not include the affliation in the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (bbbyyy)');
     });
@@ -130,12 +130,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when a nameless affiliation is passed in the props', () => {
     it('should not include the affliation in the credits string', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{}] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (bbbyyy)');
     });
@@ -143,12 +143,12 @@ describe('the ImageMetadata component', () => {
 
   describe('when all the possible metadata values are included', () => {
     it('should render the metadata string correctly', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (bbbyyy/affff)');
     });
@@ -163,73 +163,73 @@ describe('the ImageMetadata component', () => {
 
   describe('when a vanityCredits is passed in the props', () => {
     it('should hide photographer and credit on image', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
         vanityCredits={{ by: [{}], affiliation: [{}] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu ');
     });
 
     it('should override photographer and credit on image using vanity credits info', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
         vanityCredits={{ by: [{ name: 'vanity photograher' }], affiliation: [{ name: 'vanity credit' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (vanity photograher/vanity credit)');
     });
 
     it('should override photographer on image using vanity credits info', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
         vanityCredits={{ by: [{ name: 'vanity photograher' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (vanity photograher/affff)');
     });
 
     it('should override credit on image using vanity credits info', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
         vanityCredits={{ affiliation: [{ name: 'vanity credit' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (bbbyyy/vanity credit)');
     });
 
     it('should show photographer and hide credit on image using vanity credits info', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
         vanityCredits={{ by: [{ name: 'vanity photograher' }], affiliation: [{}] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (vanity photograher)');
     });
 
     it('should hide photographer and show credit on image using vanity credits info', () => {
-      const wrapper = shallow(<ImageMetadata
+      const wrapper = mount(<ImageMetadata
         subtitle="ffffg"
         caption="ttttu"
         credits={{ by: [{ name: 'bbbyyy' }], affiliation: [{ name: 'affff' }] }}
         vanityCredits={{ by: [{}], affiliation: [{ name: 'vanity credit' }] }}
       />);
-      expect(wrapper.find('span')).toHaveLength(1);
+      expect(wrapper.find('span')).toHaveLength(2);
       expect(wrapper.find('span').first().text()).toBe('ffffg ');
       expect(wrapper.text()).toBe('ffffg ttttu (vanity credit)');
     });

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -57,7 +57,7 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
       aff = (vanityAff[0] && vanityAff[0].name) || null;
     }
   }
-  const imageCaption = (): html => ({ __html: `${caption} ` });
+  const imageCaption = (): any => ({ __html: `${caption} ` });
 
   const credits = (photographer || aff) && `(${[photographer, aff].filter((name) => name).join('/')})`;
 

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -60,6 +60,7 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
 
   const credits = (photographer || aff) && `(${[photographer, aff].filter((name) => name).join('/')})`;
 
+  // String literal used for caption in order to keep caption and credits visually separate
   return !!(subtitle || caption || credits) && (
     <MetadataParagraph className="image-metadata" primaryFont={getThemeStyle(arcSite)['primary-font-family']}>
       {

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -57,6 +57,8 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
       aff = (vanityAff[0] && vanityAff[0].name) || null;
     }
   }
+  const imageCaption = (): html => ({ __html: `${caption} ` });
+
   const credits = (photographer || aff) && `(${[photographer, aff].filter((name) => name).join('/')})`;
 
   return !!(subtitle || caption || credits) && (
@@ -69,7 +71,7 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
         )
       }
       {
-        caption && `${caption} `
+        caption && <span dangerouslySetInnerHTML={imageCaption()} />
       }
       {
         credits

--- a/src/components/ImageMetadata/index.tsx
+++ b/src/components/ImageMetadata/index.tsx
@@ -57,7 +57,6 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
       aff = (vanityAff[0] && vanityAff[0].name) || null;
     }
   }
-  const imageCaption = (): any => ({ __html: `${caption} ` });
 
   const credits = (photographer || aff) && `(${[photographer, aff].filter((name) => name).join('/')})`;
 
@@ -71,7 +70,7 @@ const ImageMetadata: React.FC<ImageMetadataProps> = ({
         )
       }
       {
-        caption && <span dangerouslySetInnerHTML={imageCaption()} />
+        caption && <span dangerouslySetInnerHTML={{ __html: `${caption} ` }} />
       }
       {
         credits

--- a/stories/ImageMetadata.stories.mdx
+++ b/stories/ImageMetadata.stories.mdx
@@ -103,6 +103,55 @@ import { ImageMetadata } from '@wpmedia/engine-theme-sdk';
     </Story>
 </Canvas>
 
+** Custom ImageMetadata with HTML **
+<Canvas>
+    <Story name="Custom ImageMetadata with HTML">
+        <figure>
+            <Image
+                url={'https://arc-anglerfish-arc2-prod-corecomponents.s3.amazonaws.com/public/37UMUNYNOVCEJDZW5SBKBXNMO4.jpg'}
+                alt={'Aerial view of bridge'}
+                smallWidth={158}
+                smallHeight={89}
+                mediumWidth={274}
+                mediumHeight={154}
+                largeWidth={274}
+                largeHeight={154}
+                resizedImageOptions={{
+                    '158x89': '/r4YXPy4Eh2thx80bDTxRZM9Syhw=filters:format(jpg):quality(70)/',
+                    '274x154': '/sDwhmVtwayjjDJww8CvlWjpydGM=filters:format(jpg):quality(70)/',
+                }}
+                resizerURL={'https://corecomponents-the-prophet-prod.cdn.arcpublishing.com/resizer'}
+                breakpoints={{
+                    small: 420,
+                    medium: 768,
+                    large: 992,
+                }}
+            />
+          <figcaption>
+            <ImageMetadata
+                subtitle={text('Subtitle', 'Custom subtitle')}
+                caption={'Custom caption, where the user <i>injects some HTML</i> for more custom subtitles'}
+                credits={{
+                    affiliation: [
+                        {
+                            name: text("Affiliation", "Death to Stock Photo"),
+                            type: 'author',
+                        },
+                    ],
+                    by: [
+                        {
+                            byline: text("Byline", "John Doe (Custom credit)"),
+                            name: text("Name", "John Doe"),
+                            type: 'author',
+                        },
+                    ],
+                }}
+            />
+          </figcaption>
+        </figure>
+    </Story>
+</Canvas>
+
 ### **Override photographer and credits on ImageMetadata**
 
 <Canvas>


### PR DESCRIPTION
## Description
This PR addresses the problem with rendering HTML in image subtitles, specifically the caption part of ImageMetaData.
The user can now enter custom HTML and the styling will render correctly instead of having HTML tags exposed.

I have included a new story for the storybook, and have updated the tests to reflect what we wanted to test for.

There are a few solutions to this problem but the easiest quickest way is to use React's `dangerouslySetInnerHTML` attribute. The alternative is to use another package to parse the HTML tags and insert the produced strings in the correct place. We also use this attribute liberally throughout blocks and the SDK.

## Jira Ticket
- [TMEDIA-290](https://arcpublishing.atlassian.net/browse/TMEDIA-290)

## Acceptance Criteria
When an editor enters HTML in a Photo Center image caption, the user should see the HTML render correctly instead of outputting the HTML tags

## Test Steps
1. Checkout this branch: `git checkout TMEDIA-290/html_rendering_correction`
2.  Run storybook: `npm run storybook`
3. Click into the `ImageMetaData` section, then click `Custom ImageMetadata with HTML `.
4. Observe the HTML tags aren't present, and that the text `injects some HTML` is italicized.
5. This can also be observed in the `Elements` section of the dev inspector for any given browser. Inspect the elemtn and you can see the HTML tags that are correctly rendered in the web page.

## Effect Of Changes
### Before
HTML tags were exposed and not rendering styles correctly:
<img width="732" alt="Screen Shot 2021-07-02 at 2 10 48 PM" src="https://user-images.githubusercontent.com/82830431/124319181-7bb7d580-db3f-11eb-869c-5dac6ff5c9f2.png">

### After
HTML renders correctly, tags not present in image subtitles:
<img width="953" alt="Screen Shot 2021-07-02 at 2 11 32 PM" src="https://user-images.githubusercontent.com/82830431/124319244-8c684b80-db3f-11eb-81b6-88a951d4f273.png">

## Dependencies or Side Effects
N/A

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
