### PR TITLE
feat: Add typeof checks for fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.9.9-rc.0",
+  "version": "2.9.9-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.9.9-canary.0",
+  "version": "2.9.9-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.9.9-rc.0",
+  "version": "2.9.9-beta.0",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/engine-theme-sdk",
-  "version": "2.9.9-canary.0",
+  "version": "2.9.9-rc.0",
   "description": "SDK components for the Fusion News theme",
   "sideEffects": false,
   "main": "dist/cjs/index.js",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -49,7 +49,7 @@ try {
       if (typeof sitePropertyObject.dateLocalization.language === 'string') {
         themesLocaleList.push(sitePropertyObject.dateLocalization.language);
       }
-      // can't use ?. bc node version 
+      // can't use ?. bc node version
       if (typeof sitePropertyObject.dateLocalization.timeZone === 'string') {
         targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
       }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -46,8 +46,13 @@ try {
   Object.values(targetBlockValues.sites).forEach(({ siteProperties: sitePropertyObject }) => {
     // if site has no date localization obj
     if (sitePropertyObject.dateLocalization) {
-      themesLocaleList.push(sitePropertyObject.dateLocalization.language);
-      targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
+      if (typeof sitePropertyObject.dateLocalization.language === 'string') {
+        themesLocaleList.push(sitePropertyObject.dateLocalization.language);
+      }
+      // can't use ?. bc node version 
+      if (typeof sitePropertyObject.dateLocalization.timeZone === 'string') {
+        targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
+      }
     }
   });
 


### PR DESCRIPTION
in the src/

then install should show lisbon timezone 

won't show language as that functionality is only in canary 

`rm -rf node_modules && npm ci`

ls node_modules/timezone

```json
{
  "values": {
    "default": {
      "siteProperties": {
        "dateLocalization": {
          "language": "en",
          "timeZone": "America/New_York"
        }
      }
    },
    "sites": {
      "the*sun": {
        "siteProperties": {
          "dateLocalization": {
            "language": "fr",
            "timeZone": "Europe/Paris"
          }
        }
      },
      "the*prophet": {
        "siteProperties": {
          "dateLocalization": {
            "language": "no",
            "timeZone": "Europe/Oslo"
          }
        }
      },
      "dagen": {
        "siteProperties": {
          "dateLocalization": {
            "language": "sv",
            "timeZone": "Europe/Stockholm"
          }
        }
      },
      "site*with*empty*site*properties": {
        "siteProperties": {}
      },
      "arc*demo*1": {
        "siteProperties": {
          "dateLocalization": {
            "language": "es",
            "timeZone": "Europe/Madrid"
          }
        }
      },
      "arc*demo*2": {
        "siteProperties": {
          "dateLocalization": {
            "language": "de",
            "timeZone": "Europe/Busingen"
          }
        }
      },
      "arc*demo*3": {
        "siteProperties": {
          "dateLocalization": {
            "language": "ja",
            "timeZone": "Asia/Tokyo"
          }
        }
      },
      "arc*demo*4": {
        "siteProperties": {
          "dateLocalization": {
            "language": "ko",
            "timeZone": "America/New_York"
          }
        }
      },
      "portugal*paper": {
        "siteProperties": {
          "dateLocalization": {
            "language": "pt_PT",
            "timeZone": "Europe/Lisbon"
          }
        }
      },
      "arc*demo*korea": {
        "siteProperties": {
          "dateLocalization": {
            "language": "ko",
            "timeZone": "America/New_York"
          }
        }
      },
      "empty-obj": {
        "siteProperties": {
          "dateLocalization": {
            "language": "en"
          }
        }
      }
    }
  }
}



```