### PR TITLE
feat: Allow fallback without a language or timezone string

### DIFF
--- a/debugging-timezone-postinstall-dates.md
+++ b/debugging-timezone-postinstall-dates.md
@@ -152,6 +152,11 @@ To test this locally, add a `blocks.json` to the `src` folder. You'll already no
             "timeZone": "Pacific/Auckland"
           }
         }
+      },
+      "empty-obj": {
+        "siteProperties": {
+          "dateLocalization": {}
+        }
       }
     }
   }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -45,8 +45,12 @@ try {
   Object.values(targetBlockValues.sites).forEach(({ siteProperties: sitePropertyObject }) => {
     // if site has no date localization obj
     if (sitePropertyObject.dateLocalization) {
-      themesLocaleList.push(sitePropertyObject.dateLocalization.language);
-      targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
+      if (typeof sitePropertyObject.dateLocalization.language === 'string') {
+        themesLocaleList.push(sitePropertyObject.dateLocalization.language);
+      }
+      if (typeof sitePropertyObject.dateLocalization.timeZone === 'string') {
+        targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
+      }
     }
   });
 


### PR DESCRIPTION
## Description
Better error handling if empty dateLocalization obj

## Jira Ticket
- [TMEDIA-384](https://arcpublishing.atlassian.net/browse/TMEDIA-384)

## Acceptance Criteria
in the src/

then install should show lisbon timezone 

won't show language as that functionality is only in canary 

`rm -rf node_modules && npm ci`

ls node_modules/timezone

```json
{
  "values": {
    "default": {
      "siteProperties": {
        "dateLocalization": {
          "language": "en",
          "timeZone": "America/New_York"
        }
      }
    },
    "sites": {
      "the*sun": {
        "siteProperties": {
          "dateLocalization": {
            "language": "fr",
            "timeZone": "Europe/Paris"
          }
        }
      },
      "the*prophet": {
        "siteProperties": {
          "dateLocalization": {
            "language": "no",
            "timeZone": "Europe/Oslo"
          }
        }
      },
      "dagen": {
        "siteProperties": {
          "dateLocalization": {
            "language": "sv",
            "timeZone": "Europe/Stockholm"
          }
        }
      },
      "site*with*empty*site*properties": {
        "siteProperties": {}
      },
      "arc*demo*1": {
        "siteProperties": {
          "dateLocalization": {
            "language": "es",
            "timeZone": "Europe/Madrid"
          }
        }
      },
      "arc*demo*2": {
        "siteProperties": {
          "dateLocalization": {
            "language": "de",
            "timeZone": "Europe/Busingen"
          }
        }
      },
      "arc*demo*3": {
        "siteProperties": {
          "dateLocalization": {
            "language": "ja",
            "timeZone": "Asia/Tokyo"
          }
        }
      },
      "arc*demo*4": {
        "siteProperties": {
          "dateLocalization": {
            "language": "ko",
            "timeZone": "America/New_York"
          }
        }
      },
      "portugal*paper": {
        "siteProperties": {
          "dateLocalization": {
            "language": "pt_PT",
            "timeZone": "Europe/Lisbon"
          }
        }
      },
      "arc*demo*korea": {
        "siteProperties": {
          "dateLocalization": {
            "language": "ko",
            "timeZone": "America/New_York"
          }
        }
      },
      "empty-obj": {
        "siteProperties": {
          "dateLocalization": {
            "language": "en"
          }
        }
      }
    }
  }
}



```

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
