### PR TITLE
ci: Use dependabot test and target head

### DIFF
--- a/.github/workflows/dependabot-test.yml
+++ b/.github/workflows/dependabot-test.yml
@@ -1,0 +1,19 @@
+name: Dependabot Workflow
+on: pull_request_target
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Check out the pull request HEAD
+          ref: ${{ github.event.pull_request.head.sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm t


### PR DESCRIPTION
- Add dependabot testing based on updated github test and github actions 

via https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions