### PR TITLE
Tmedia 423 meridiem date time

### DIFF
--- a/debugging-timezone-postinstall-dates.md
+++ b/debugging-timezone-postinstall-dates.md
@@ -276,7 +276,7 @@ To test this live, run
 
 
 To see the included locales (language and country) and folders:
- `ls node_modules/timezone/`
+ `ls node_modules/@wpmedia/timezone/`
 
 To test including blocks.json, use the included blocks.json above and uncomment the following test: 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7615,9 +7615,9 @@
       }
     },
     "@wpmedia/timezone": {
-      "version": "1.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/timezone/1.1.0/89a428cbb622d3e20933277bd872fe52166b2a4a57bb5001d770b1140354c93e",
-      "integrity": "sha512-DO9B7E5I+pbU5gvPklVlw34tV5b/ciYPztFBSjXPOqDQpnx9NeQ8+Nae6pKPZYUg4lAsGKH6BoaUMwnsKRCA+A=="
+      "version": "1.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/timezone/1.1.1/0ad6c48a887bc2b122d141a1eb5fb9a81b5f2ee7195d0d81f38aab7366919c2b",
+      "integrity": "sha512-nN6M2q8cyJELhihJ65t4CVFWr7QgZSnO+aAEXVFdh/k9RpQJd7EtGVLjZyd8HzAFwhiGv+O4Iz7nclbOnNXEWg=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7614,6 +7614,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wpmedia/timezone": {
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/timezone/1.1.0/89a428cbb622d3e20933277bd872fe52166b2a4a57bb5001d770b1140354c93e",
+      "integrity": "sha512-DO9B7E5I+pbU5gvPklVlw34tV5b/ciYPztFBSjXPOqDQpnx9NeQ8+Nae6pKPZYUg4lAsGKH6BoaUMwnsKRCA+A=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -22641,11 +22646,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "timezone": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/timezone/-/timezone-1.0.23.tgz",
-      "integrity": "sha512-yhQgk6qmSLB+TF8HGmApZAVI5bfzR1CoKUGr+WMZWmx75ED1uDewAZA8QMGCQ70TEv4GmM8pDB9jrHuxdaQ1PA=="
     },
     "tiny-emitter": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "@arc-fusion/prop-types": "^0.1.5",
+    "@wpmedia/timezone": "^1.1.0",
     "dom-parser": "^0.1.6",
     "is-react": "^1.3.3",
     "lazy-child": "^0.3.1",
@@ -102,7 +103,6 @@
     "react-swipeable": "^5.5.0",
     "rimraf": "^3.0.2",
     "styled-components": "^4.4.1",
-    "thumbor-lite": "^0.1.6",
-    "timezone": "1.0.23"
+    "thumbor-lite": "^0.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@arc-fusion/prop-types": "^0.1.5",
-    "@wpmedia/timezone": "^1.1.0",
+    "@wpmedia/timezone": "^1.1.1",
     "dom-parser": "^0.1.6",
     "is-react": "^1.3.3",
     "lazy-child": "^0.3.1",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -11,7 +11,7 @@ let themesLocaleList = [];
 
 let targetTimeZones = [];
 
-const packageName = 'timezone';
+const packageName = '@wpmedia/timezone';
 
 // in this case, wherever npm i was called
 // init cwd is the filepath of the initiating command

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -73,9 +73,9 @@ it('handles french meridiems', () => {
       '%B %d, %Y %l:%M %P %Z',
       'fr',
       'Europe/Paris',
-    )).toMatchInlineSnapshot('"janvier 02, 2000  2:00 am CET"');
+    ),
+  ).toMatchInlineSnapshot('"janvier 02, 2000  2:00 am CET"');
 });
-
 
 it('handles spanish meridiems', () => {
   expect(
@@ -84,7 +84,8 @@ it('handles spanish meridiems', () => {
       '%B %d, %Y %l:%M %P %Z',
       'es',
       'Europe/Paris',
-    )).toMatchInlineSnapshot('"enero 02, 2000  2:00 pm CET"');
+    ),
+  ).toMatchInlineSnapshot('"enero 02, 2000  2:00 pm CET"');
 });
 
 // To test this, see debugging-timezone-postinstall-dates.md

--- a/src/utils/localizeDate.test.ts
+++ b/src/utils/localizeDate.test.ts
@@ -66,6 +66,27 @@ it('supports Paris timezone', () => {
   ).toMatchInlineSnapshot('"January 02, 2000  2:00 am CET"');
 });
 
+it('handles french meridiems', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02 01:00',
+      '%B %d, %Y %l:%M %P %Z',
+      'fr',
+      'Europe/Paris',
+    )).toMatchInlineSnapshot('"janvier 02, 2000  2:00 am CET"');
+});
+
+
+it('handles spanish meridiems', () => {
+  expect(
+    localizeDateHelper(
+      '2000-01-02 13:00',
+      '%B %d, %Y %l:%M %P %Z',
+      'es',
+      'Europe/Paris',
+    )).toMatchInlineSnapshot('"enero 02, 2000  2:00 pm CET"');
+});
+
 // To test this, see debugging-timezone-postinstall-dates.md
 // 1. Add a blocks.json file in the src/ folder from above doc
 // 2. run `rm -rf node_modules && npm ci --production`

--- a/src/utils/localizeDateHelper.ts
+++ b/src/utils/localizeDateHelper.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 // tz docs https://bigeasy.github.io/timezone/
-const tz = require('timezone')(
-  require('timezone/zones'),
-  require('timezone/locales'),
+const tz = require('@wpmedia/timezone')(
+  require('@wpmedia/timezone/zones'),
+  require('@wpmedia/timezone/locales'),
 );
 
 function localizeDateHelper(


### PR DESCRIPTION
## Description
Use meridiems

## Jira Ticket
- [TMEDIA-423](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=875&modal=detail&selectedIssue=TMEDIA-423&assignee=5e387d6a1b1d910e5dfd7a9b)

## Acceptance Criteria
Use meridiems
- publish our fork

## Test Steps
- `rm -rf node_modules && npm i && npm t`

## Effect Of Changes

```
### Before
  src/utils/localizeDate.test.ts
  ● handles french meridiems

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `handles french meridiems 1`

    Snapshot: "janvier 02, 2000  2:00 am CET"
    Received: "janvier 02, 2000  2:00  CET"

      75 |       'Europe/Paris',
      76 |     ),
    > 77 |   ).toMatchInlineSnapshot('"janvier 02, 2000  2:00 am CET"');
         |     ^
      78 | });
      79 | 
      80 | it('handles spanish meridiems', () => {

      at Object.<anonymous>.it (src/utils/localizeDate.test.ts:77:5)

  ● handles spanish meridiems

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `handles spanish meridiems 1`

    Snapshot: "enero 02, 2000  2:00 pm CET"
    Received: "enero 02, 2000  2:00  CET"

      86 |       'Europe/Paris',
      87 |     ),
    > 88 |   ).toMatchInlineSnapshot('"enero 02, 2000  2:00 pm CET"');
         |     ^
      89 | });
      90 | 
      91 | // To test this, see debugging-timezone-postinstall-dates.md

      at Object.<anonymous>.it (src/utils/localizeDate.test.ts:88:5)
```

### After
Meridiems included in @wpmedia/timezone library (see tests)

## Dependencies or Side Effects
- work already done https://github.com/WPMedia/timezone

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
