### PR TITLE
Generating canonical links for article, video and gallery pages

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -1833,6 +1833,44 @@ describe('the meta data', () => {
     });
   });
 
+  describe('Canonical links', () => {
+    it('must have canonical tag for article pages', () => {
+      const metaValue = metaValues({
+        'page-type': 'article',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(1);
+    });
+
+    it('must have canonical tag for video pages', () => {
+      const metaValue = metaValues({
+        'page-type': 'video',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(1);
+    });
+
+    it('must have canonical tag for gallery pages', () => {
+      const metaValue = metaValues({
+        'page-type': 'gallery',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(1);
+    });
+
+    it('must NOT have canonical tag for pages other than gallery, video or article', () => {
+      const metaValue = metaValues({
+        'page-type': 'homepage',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(0);
+    });
+  });
+
   describe('facebook article meta', () => {
     it('articles pages must have og:type = article', () => {
       const metaValue = metaValues({

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -96,6 +96,8 @@ interface Props {
       metadata_description?: string;
       metadata_title?: string;
     };
+    canonical_website?: string | null;
+    canonical_url?: string | null;
   } | null;
   websiteName?: string | null;
   websiteDomain?: string | null;
@@ -129,6 +131,7 @@ const MetaData: React.FC<Props> = ({
   let homepageMetaDataTags = null;
   let nativoMetaDataTags = null;
   let commonTagsOnPage = true;
+  let canonicalLink = null;
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
   const { getImgURL, getImgAlt } = require('./promoImageHelper');
@@ -222,6 +225,13 @@ const MetaData: React.FC<Props> = ({
           }
         </>
       );
+
+      if (gc) {
+        const canonicalUrl = gc.canonical_url || '';
+        canonicalLink = (
+          <link rel="canonical" href={`${websiteDomain}${canonicalUrl}`} />
+        );
+      }
     }
   } else if (pageType === 'author') {
     const author = (gc && gc.authors && gc.authors.length) ? gc.authors[0] : {};
@@ -428,6 +438,7 @@ const MetaData: React.FC<Props> = ({
       {customMetaTags}
       {commonTagsOnPage && twitterTags}
       {nativoMetaDataTags}
+      {canonicalLink}
     </>
   );
 };
@@ -461,6 +472,8 @@ MetaData.propTypes = {
       metadata_description: PropTypes.string,
       metadata_title: PropTypes.string,
     }),
+    canonical_website: PropTypes.string,
+    canonical_url: PropTypes.string,
   }),
   /** The name of the website */
   websiteName: PropTypes.string,

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -96,7 +96,6 @@ interface Props {
       metadata_description?: string;
       metadata_title?: string;
     };
-    canonical_website?: string | null;
     canonical_url?: string | null;
   } | null;
   websiteName?: string | null;
@@ -472,7 +471,6 @@ MetaData.propTypes = {
       metadata_description: PropTypes.string,
       metadata_title: PropTypes.string,
     }),
-    canonical_website: PropTypes.string,
     canonical_url: PropTypes.string,
   }),
   /** The name of the website */


### PR DESCRIPTION
## Description
Generating canonical links for article, video and gallery pages

## Jira Ticket
https://arcpublishing.atlassian.net/browse/TMEDIA-432

## Acceptance Criteria
Themes default output type includes <link rel="canonical"> based on the template types: Article, Video, Gallery

Ensure code behavior matches ALC documentation https://corecomponents.arcpublishing.com/alc/arc-products/themes/user-docs/page-template-guide/page-types/#link-rel-=-“canonical”

## Test Steps

- Pull this branch down.
- Pull reasonably latest PB Data (if you haven't done already)
- Run local environment with local engine-sdk linked
- View preview of published version of the page `Test - JC - Kitchen Sink Article` (The published page is the article-right-rail version).
- After page loads, inspect header for the presence of a canonical link tag.

## Effect Of Changes
### Before
No canonical links were ever generated

### After
Canonical links for article, video and gallery pages are now generated.

## Dependencies or Side Effects
Solution will need refactoring (if not a altogether new MetaData component )for ecommerce theme.

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [ x] Confirmed this PR has reasonable code coverage
  - [ x] Confirmed this PR has unit test files
  - [ x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
