### PR TITLE
TMEDIA-481: remove mobile-unfriendly prev/next image tap targets

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -456,10 +456,20 @@ const Gallery: React.FC<GalleryProps> = ({
             primaryFont={controlsFont}
             dangerouslySetInnerHTML={ImageCountTextOutput}
           />
-          <ControlsButton type="button" aria-label={previousImagePhrase} onClick={(): void => prevHandler()}>
+          <ControlsButton
+            aria-label={previousImagePhrase}
+            className="gallery--top-control-button"
+            onClick={(): void => prevHandler()}
+            type="button"
+          >
             <ChevronLeftIcon fill={greyFill} />
           </ControlsButton>
-          <ControlsButton type="button" aria-label={nextImagePhrase} onClick={(): void => nextHandler()}>
+          <ControlsButton
+            aria-label={nextImagePhrase}
+            className="gallery--top-control-button"
+            onClick={(): void => nextHandler()}
+            type="button"
+          >
             <ChevronRightIcon fill={greyFill} />
           </ControlsButton>
         </ControlContainer>

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -26,6 +26,12 @@ export const ControlsDiv = styled.div`
 `;
 
 export const ControlContainer = styled.div`
+  @media screen and (max-width: 48rem) {
+    .gallery--top-control-button {
+      display: none;
+    }
+  }
+
   flex: 0 0 auto;
   line-height: ${rem('16px')};
   margin: 6px 0;
@@ -62,7 +68,7 @@ export const PlaybackText = styled.span<{ primaryFont: string }>`
   margin: 0 30px 0 4px;
 `;
 
-export const ImageCountText = styled.p<{ primaryFont: string }>`
+export const ImageCountText = styled.span<{ primaryFont: string }>`
   font-family: ${(props): string => props.primaryFont};
   display: inline-block;
   margin: 0 0 0 12px;


### PR DESCRIPTION
## Description
Fix tap targets being too small by removing duplicate ones

## Jira Ticket
- [TMEDIA-481](https://arcpublishing.atlassian.net/browse/TMEDIA-481)

## Acceptance Criteria

No left and right tap buttons above the image gallery. Use only the on-image ones 

Pass the lighthouse seo mobile-friendliness test for those tap targets (aka remove them) 

## Test Steps
- `git checkout TMEDIA-481-seo-remove-small-image-tap-targets`
- link engine theme sdk via .env 
- `npx fusion start -f`
- go to http://localhost/pf/test-article-page/?_website=the-gazette
- Scroll down to see a gallery and its controls 
- Ensure that left and right targets can still be accessed from on-image controls 
- Then, run lighthouse test on mobile for seo to validate that mobile friendly tap targets have been removed 

![Screen Shot 2021-09-14 at 10 03 03](https://user-images.githubusercontent.com/5950956/133286121-c2fed5d5-97c6-4e8f-94b3-674faa729cb4.png)


## Effect Of Changes
### Before

<img width="720" alt="Screen Shot 2021-09-14 at 09 57 12" src="https://user-images.githubusercontent.com/5950956/133281705-6a2fddee-cbc0-4a0d-a059-bab9d11937df.png">

<img width="149" alt="Screen Shot 2021-09-14 at 09 57 32" src="https://user-images.githubusercontent.com/5950956/133281761-529d8f18-fbe2-485b-a7da-9def38051e72.png">

on an article page http://localhost/pf/test-article-page/?_website=the-gazette: 

<img width="364" alt="Screen Shot 2021-09-14 at 10 19 18" src="https://user-images.githubusercontent.com/5950956/133285540-f861adde-6a57-4fdc-bda4-ee15f48a1a30.png">

![Screen Shot 2021-09-14 at 10 07 22](https://user-images.githubusercontent.com/5950956/133285734-7a5330ba-16b4-4ac2-b632-4aa95282ee1b.png)

### After

<img width="112" alt="Screen Shot 2021-09-14 at 09 56 26" src="https://user-images.githubusercontent.com/5950956/133281602-df83fb3c-4602-44f9-86e1-cf225e13c090.png">

on an article page http://localhost/pf/test-article-page/?_website=the-gazette: 

<img width="334" alt="Screen Shot 2021-09-14 at 10 15 41" src="https://user-images.githubusercontent.com/5950956/133285321-fa5559da-7eb4-4f8e-b7b0-98c05826ab4b.png">

<img width="491" alt="Screen Shot 2021-09-14 at 10 19 44" src="https://user-images.githubusercontent.com/5950956/133285628-37a88562-9bf8-4a6d-a545-9ef88c574537.png">

## Dependencies or Side Effects
- relying upon next/prev on image

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
