### PR TITLE
TMEDIA-446 - Gallery Ad Defects

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -190,6 +190,9 @@ const Gallery: React.FC<GalleryProps> = ({
 
   const prevHandler = (): void => {
     if (page <= 0) {
+      if (isAdActive()) {
+        setAdDone(true);
+      }
       return;
     }
     const pg = page - 1;
@@ -206,6 +209,9 @@ const Gallery: React.FC<GalleryProps> = ({
 
   const nextHandler = (): void => {
     if (page >= galleryElements.length - 1) {
+      if (isAdActive()) {
+        setAdDone(true);
+      }
       return;
     }
     const pg = page + 1;
@@ -396,9 +402,11 @@ const Gallery: React.FC<GalleryProps> = ({
       return undefined;
     }
 
-    const handler = (): void => {
-      setAdHidding(false);
-      setAdDone(true);
+    const handler = (event): void => {
+      if (event.propertyName === 'transform') {
+        setAdHidding(false);
+        setAdDone(true);
+      }
     };
 
     carousel.addEventListener('transitionend', handler);


### PR DESCRIPTION
## Description
Fixed two issues:

1. Fix issue noted in ticket where Ad would show then disappear
2. Fix issue if Ad is shown on the last or first item the user could not click next/previous to show the image

## Jira Ticket
- [TMEDIA-](https://arcpublishing.atlassian.net/browse/TMEDIA-446)

## Acceptance Criteria
Interstitial gallery ads display when the user reaches an ad according to the interstitialClicks value set in site properties and images remain hidden while in that state.

## Test Steps
- Using storybook open the Gallery with interstitial ad story - http://localhost:6006/iframe.html?id=gallery--interstitial-ad&viewMode=story
- Using the arrow buttons navigate forward until you see an Ad
- Verify the ad shows
- Verify the ad only disappears when you navigate to the next image
- Verify when the ad is shown as the last item you are able to use the next button to move the ad and see the last image

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
