### PR TITLE
TMEDIA-534: Canonical link for all page types

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -31,6 +31,7 @@ const fallbackImageRemote = 'https://remote-site.com/images/fallback_image_remot
 
 /* eslint-disable @typescript-eslint/camelcase */
 const globalContentComplete = {
+  _id: '/section/url',
   description: {
     basic: 'this is a description',
   },
@@ -62,6 +63,7 @@ const globalContentComplete = {
     {
       name: 'payload name',
       description: 'payload description',
+      slug: 'tagSlug',
     },
   ],
   canonical_url: '/path/to/global-content/',
@@ -69,6 +71,7 @@ const globalContentComplete = {
   metadata: {
     metadata_description: 'metadata section description',
     metadata_title: 'metadata section title',
+    q: 'searchQuery',
   },
 };
 
@@ -154,21 +157,25 @@ const wrapperGenerator = (
   globalContent: GlobalContentBag,
   fallbackImage: string = fallbackImageLocal,
   canonicalDomain = null,
+  canonicalResolver = null,
+  outputCanonicalLink = false,
 ): ShallowWrapper => (
   shallow(
     <MetaData
-      metaValue={metaValue}
-      MetaTag={jest.fn()}
-      MetaTags={jest.fn()}
-      globalContent={globalContent}
-      twitterUsername={twitterUsername}
-      websiteName={websiteName}
-      resizerURL={resizerURL}
       arcSite={arcSite}
-      websiteDomain={websiteDomain}
+      canonicalDomain={canonicalDomain}
+      canonicalResolver={canonicalResolver}
       facebookAdmins={facebookAdmins}
       fallbackImage={fallbackImage}
-      canonicalDomain={canonicalDomain}
+      globalContent={globalContent}
+      MetaTag={jest.fn()}
+      MetaTags={jest.fn()}
+      metaValue={metaValue}
+      outputCanonicalLink={outputCanonicalLink}
+      resizerURL={resizerURL}
+      twitterUsername={twitterUsername}
+      websiteDomain={websiteDomain}
+      websiteName={websiteName}
     />,
   )
 );
@@ -1837,13 +1844,13 @@ describe('the meta data', () => {
   });
 
   describe('Canonical links', () => {
-    const canonicalDomainName = 'http://canonical.com/';
+    const canonicalDomainName = 'http://canonical.com';
     it('must have canonical tag for article pages', () => {
       const metaValue = metaValues({
         'page-type': 'article',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', canonicalDomainName);
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', canonicalDomainName, null, true);
       expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${canonicalDomainName}${globalContentComplete.canonical_url}`);
     });
 
@@ -1861,7 +1868,7 @@ describe('the meta data', () => {
         'page-type': 'video',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', canonicalDomainName);
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', canonicalDomainName, null, true);
       expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${canonicalDomainName}${globalContentComplete.canonical_url}`);
     });
 
@@ -1870,19 +1877,17 @@ describe('the meta data', () => {
         'page-type': 'gallery',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', canonicalDomainName);
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', canonicalDomainName, null, true);
       expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${canonicalDomainName}${globalContentComplete.canonical_url}`);
     });
 
-    // The follow tests are not working as we don't have the logic for the path URL part
-    /*
     it('must have canonical tag for tag pages', () => {
       const metaValue = metaValues({
         'page-type': 'tag',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
-      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}`);
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', null, null, true);
+      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}/tags/${globalContentComplete.Payload[0].slug}`);
     });
 
     it('must have canonical tag for author pages', () => {
@@ -1890,8 +1895,8 @@ describe('the meta data', () => {
         'page-type': 'author',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
-      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}`);
+      const wrapper = wrapperGenerator(metaValue, globalContentAuthor, '', null, null, true);
+      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}${globalContentAuthor.authors[0].bio_page}`);
     });
 
     it('must have canonical tag for section pages', () => {
@@ -1899,8 +1904,8 @@ describe('the meta data', () => {
         'page-type': 'section',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
-      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}`);
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', null, null, true);
+      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}${globalContentComplete._id}`);
     });
 
     it('must have canonical tag for search pages', () => {
@@ -1908,8 +1913,8 @@ describe('the meta data', () => {
         'page-type': 'search',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, globalContentComplete);
-      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}`);
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', null, null, true);
+      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}/search/${globalContentComplete.metadata.q}`);
     });
 
     it('must have canonical tag for homepage pages', () => {
@@ -1917,7 +1922,7 @@ describe('the meta data', () => {
         'page-type': 'homepage',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, {});
+      const wrapper = wrapperGenerator(metaValue, {}, '', null, null, true);
       expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}`);
     });
 
@@ -1926,10 +1931,27 @@ describe('the meta data', () => {
         'page-type': 'homepage',
         title: 'the-sun',
       });
-      const wrapper = wrapperGenerator(metaValue, {});
+      const wrapper = wrapperGenerator(metaValue, {}, '', null, null, true);
       expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}`);
     });
-    */
+
+    it('will not output canonical link if outputCanonicalLink is false', () => {
+      const metaValue = metaValues({
+        'page-type': 'homepage',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, {}, '', null, null, false);
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(0);
+    });
+
+    it('will not output canonical link if canonicalDomain does not resolve to a valid url', () => {
+      const metaValue = metaValues({
+        'page-type': 'section',
+        title: 'the-sun',
+      });
+      const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', 'invalidDomain', null, true);
+      expect(wrapper.find('link[rel="canonical"]').length).toBe(0);
+    });
 
     it('does not output for an unknown page type', () => {
       const metaValue = metaValues({

--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -172,6 +172,7 @@ const wrapperGenerator = (
       MetaTags={jest.fn()}
       metaValue={metaValue}
       outputCanonicalLink={outputCanonicalLink}
+      requestUri="/test/?fizz=buzz&query=search&foo=bar&foo=baz"
       resizerURL={resizerURL}
       twitterUsername={twitterUsername}
       websiteDomain={websiteDomain}
@@ -1887,7 +1888,7 @@ describe('the meta data', () => {
         title: 'the-sun',
       });
       const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', null, null, true);
-      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}/tags/${globalContentComplete.Payload[0].slug}`);
+      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}/tags/${globalContentComplete.Payload[0].slug}/`);
     });
 
     it('must have canonical tag for author pages', () => {
@@ -1914,7 +1915,7 @@ describe('the meta data', () => {
         title: 'the-sun',
       });
       const wrapper = wrapperGenerator(metaValue, globalContentComplete, '', null, null, true);
-      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}/search/${globalContentComplete.metadata.q}`);
+      expect(wrapper.find('link[rel="canonical"]').prop('href')).toBe(`${websiteDomain}/search/${globalContentComplete.metadata.q}/`);
     });
 
     it('must have canonical tag for homepage pages', () => {

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -3,14 +3,55 @@
 import React, { ReactElement } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
+import { URL } from 'url';
 
 interface CustomMetaData {
   metaName: string;
   metaValue: string;
 }
 
-interface GlobalContentBag {
-  [x: string]: unknown;
+interface GlobalContent {
+  _id?: string;
+  authors?: Array<{
+    bio?: string;
+    bio_page?: string;
+    byline?: string;
+    image?: string | {
+      alt_text?: string;
+      url?: string;
+    };
+    name?: string;
+  }>;
+  canonical_url?: string;
+  canonical_website?: string;
+  description?: {
+    basic?: string;
+  };
+  headlines?: {
+    basic?: string;
+  };
+  metadata?: {
+    metadata_description?: string;
+    metadata_title?: string;
+    q?: string;
+  };
+  name?: string;
+  Payload?: Array<{
+    description?: string;
+    name?: string;
+    slug?: string;
+  }>;
+  taxonomy?: {
+    seo_keywords?: Array<string>;
+    tags?: Array<{
+        slug?: string;
+    }>;
+  };
+  websites?: {
+    [x: string]: {
+      website_url?: string;
+    };
+  };
 }
 
 const getCustomMetaData = (metaHTMLString: string): Array<CustomMetaData> => {
@@ -42,7 +83,35 @@ const generateCustomMetaTags = (metaData, MetaTag, MetaTags): ReactElement => {
   );
 };
 
-const generateUrl = (arcSite: string, websiteDomain: string, gc: GlobalContentBag): string => {
+const buildUrl = (domain, path) => {
+  try {
+    const url = new URL(path || '', domain);
+    return url.href;
+  } catch {
+    return null;
+  }
+};
+
+const getPageCanonicalUrl = (pageType, domain, globalContent) => {
+  const globalCanonicalPath = globalContent?.canonical_url;
+  const authorCanonicalPath = globalContent?.authors ? globalContent?.authors[0]?.bio_page : '';
+  const searchCanonicalPath = globalContent?.metadata ? `search/${globalContent?.metadata.q}` : '';
+  const tagCanonicalPath = globalContent?.Payload ? `tags/${globalContent?.Payload[0]?.slug}` : '';
+
+  const canonicalUrlMapping = {
+    article: buildUrl(domain, globalCanonicalPath),
+    author: buildUrl(domain, authorCanonicalPath),
+    gallery: buildUrl(domain, globalCanonicalPath),
+    homepage: domain,
+    search: buildUrl(domain, searchCanonicalPath),
+    section: buildUrl(domain, globalContent?._id || ''),
+    tag: buildUrl(domain, tagCanonicalPath),
+    video: buildUrl(domain, globalCanonicalPath),
+  };
+  return canonicalUrlMapping[pageType];
+};
+
+const generateUrl = (arcSite: string, websiteDomain: string, gc: GlobalContent): string => {
   const siteData = gc && gc.websites && gc.websites[arcSite];
   if (!siteData) {
     return null;
@@ -61,65 +130,17 @@ const normalizeFallbackImage = (websiteDomain: string, url: string): string | nu
   return url;
 };
 
+interface CanonicalResolver {
+  (pageType: string, defaultResolution: string): string | null;
+}
+
 interface Props {
-  /** The MetaTag function that is passed into an output type */
-  MetaTag: Function;
-  /** The MetaTags function that is passed into an output type */
-  MetaTags: Function;
-  /** The metaValue function that is passed into an output type */
-  metaValue: Function;
-  /**
-   * The globalContent object that is obtained from the
-   * useFusionContext() in the fusion:context module
-   * */
-  globalContent?: {
-    name?: string;
-    description?: {
-      basic?: string;
-    };
-    headlines?: {
-      basic?: string;
-    };
-    taxonomy?: {
-      seo_keywords?: Array<string>;
-      tags?: Array<{
-          slug?: string;
-      }>;
-    };
-    authors?: Array<{
-      bio?: string;
-      byline?: string;
-      image?: string | {
-        url?: string;
-        alt_text?: string;
-      };
-      name?: string;
-    }>;
-    Payload?: Array<{
-      description?: string;
-      name?: string;
-    }>;
-    metadata?: {
-      metadata_description?: string;
-      metadata_title?: string;
-    };
-    canonical_url?: string | null;
-  } | null;
-  /** The name of the website */
-  websiteName?: string | null;
-  /** The domain name of the website */
-  websiteDomain?: string | null;
-  /** The canonical domain name to be used for article, video and gallery pages */
-  canonicalDomain?: string | null;
-  /**
-   * The twitter user name to be output within the twitter:site meta tag -
-   * Do not include the @ at the start of the name
-   * */
-  twitterUsername?: string | null;
-  /** Resizer URL - Full Domain */
-  resizerURL?: string | null;
   /** The arcSite ID */
   arcSite?: string | null;
+  /** The canonical domain name to be used for article, video and gallery pages */
+  canonicalDomain?: string | null;
+  /** A resolver function that allows a caller to override the canonical resolution */
+  canonicalResolver?: CanonicalResolver | null;
   /** Used to set the value of the fb:admins meta property */
   facebookAdmins?: string | null;
   /**
@@ -127,21 +148,47 @@ interface Props {
    * such as og:image, twitter image, etc
    * */
   fallbackImage?: string | null;
+  /**
+   * The globalContent object that is obtained from the
+   * useFusionContext() in the fusion:context module
+   * */
+  globalContent?: GlobalContent | null;
+  /** The MetaTag function that is passed into an output type */
+  MetaTag: Function;
+  /** The MetaTags function that is passed into an output type */
+  MetaTags: Function;
+  /** The metaValue function that is passed into an output type */
+  metaValue: Function;
+  /** A flag to determine if a canonical link should be included in the ouput head */
+  outputCanonicalLink?: boolean | false;
+  /** Resizer URL - Full Domain */
+  resizerURL?: string | null;
+  /**
+   * The twitter user name to be output within the twitter:site meta tag -
+   * Do not include the @ at the start of the name
+   * */
+  twitterUsername?: string | null;
+  /** The domain name of the website */
+  websiteDomain?: string | null;
+  /** The name of the website */
+  websiteName?: string | null;
 }
 
 const MetaData: React.FC<Props> = ({
+  arcSite,
+  canonicalDomain,
+  canonicalResolver,
+  facebookAdmins,
+  fallbackImage,
+  globalContent: gc,
   MetaTag,
   MetaTags,
   metaValue,
-  globalContent: gc,
-  websiteName,
-  websiteDomain,
-  canonicalDomain,
-  twitterUsername,
+  outputCanonicalLink,
   resizerURL,
-  arcSite,
-  facebookAdmins,
-  fallbackImage,
+  twitterUsername,
+  websiteDomain,
+  websiteName,
 }) => {
   const pageType = metaValue('page-type');
 
@@ -439,18 +486,17 @@ const MetaData: React.FC<Props> = ({
     </>
   );
 
-  // Canonical Link
-  const canonicalDomainMapping = {
-    article: canonicalDomain,
-    video: canonicalDomain,
-    gallery: canonicalDomain,
-  };
+  if (outputCanonicalLink) {
+    const defaultResolution = getPageCanonicalUrl(pageType, canonicalDomain || websiteDomain, gc);
+    const canonicalUrl = canonicalResolver
+      ? canonicalResolver(pageType, defaultResolution)
+      : defaultResolution;
 
-  if (canonicalDomainMapping[pageType]) {
-    const pathURL = gc?.canonical_url || '';
-    canonicalLink = (
-      <link rel="canonical" href={`${canonicalDomainMapping[pageType]}${pathURL}`} />
-    );
+    if (canonicalUrl) {
+      canonicalLink = (
+        <link rel="canonical" href={canonicalUrl} />
+      );
+    }
   }
 
   const customMetaTags = generateCustomMetaTags(metaData, MetaTag, MetaTags);
@@ -473,9 +519,10 @@ const MetaData: React.FC<Props> = ({
 };
 
 MetaData.propTypes = {
-  MetaTag: PropTypes.func,
-  MetaTags: PropTypes.func,
-  metaValue: PropTypes.func,
+  arcSite: PropTypes.string,
+  canonicalDomain: PropTypes.string,
+  facebookAdmins: PropTypes.string,
+  fallbackImage: PropTypes.string,
   globalContent: PropTypes.shape({
     name: PropTypes.string,
     description: PropTypes.shape({
@@ -496,14 +543,14 @@ MetaData.propTypes = {
     }),
     canonical_url: PropTypes.string,
   }),
-  websiteName: PropTypes.string,
-  websiteDomain: PropTypes.string,
-  canonicalDomain: PropTypes.string,
-  twitterUsername: PropTypes.string,
+  MetaTag: PropTypes.func,
+  MetaTags: PropTypes.func,
+  metaValue: PropTypes.func,
+  outputCanonicalLink: PropTypes.bool,
   resizerURL: PropTypes.string,
-  arcSite: PropTypes.string,
-  facebookAdmins: PropTypes.string,
-  fallbackImage: PropTypes.string,
+  twitterUsername: PropTypes.string,
+  websiteDomain: PropTypes.string,
+  websiteName: PropTypes.string,
 };
 
 export default MetaData;

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -93,7 +93,7 @@ const buildUrl = (domain, path) => {
 };
 
 const getUrlParameters = (requestUri = ''): {[key: string]: string | [string]} => {
-  const matches = Array.from(requestUri.matchAll(/(?:[\&\?]?([a-z0-9\-\.\_\~]+)=([a-z0-9\-\.\_\~]+))+?/g));
+  const matches = Array.from(requestUri.matchAll(/(?:[\&\?]?([\w\d\%\-\.\_\~]+)=([\w\d\%\-\.\_\~]+)){:10}?/gi));
   return matches.reduce((accumulator, [, key, value]) => {
     if (accumulator.hasOwnProperty(key)) {
       return ({

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -83,7 +83,7 @@ const generateCustomMetaTags = (metaData, MetaTag, MetaTags): ReactElement => {
   );
 };
 
-const buildUrl = (domain, path) => {
+const buildUrl = (domain, path): string => {
   try {
     const url = new URL(path || '', domain);
     return url.href;
@@ -92,12 +92,12 @@ const buildUrl = (domain, path) => {
   }
 };
 
-const getUrlParameters = (requestUri = ''): {[key: string]: string | [string]} => {
+const getUrlParameters = (requestUri = ''): {[key: string]: string | string[]} => {
   const matches = Array.from(
-    requestUri.matchAll(/(?:[\&\?]?([\w\d\%\-\.\_\~]{1:100})=([\w\d\%\-\.\_\~]{1:100})){:10}?/gi)
+    requestUri.matchAll(/(?:[&?]?([\w\d%\-._~]{1:100})=([\w\d%\-._~]{1:100})){:10}?/gi),
   );
   return matches.reduce((accumulator, [, key, value]) => {
-    if (accumulator.hasOwnProperty(key)) {
+    if (accumulator[key]) {
       return ({
         ...accumulator,
         [key]: [...(
@@ -111,7 +111,7 @@ const getUrlParameters = (requestUri = ''): {[key: string]: string | [string]} =
   }, {});
 };
 
-const getPageCanonicalUrl = (pageType, domain, globalContent, requestUri) => {
+const getPageCanonicalUrl = (pageType, domain, globalContent, requestUri): string => {
   const urlParameters = getUrlParameters(requestUri);
   const authorCanonicalPath = globalContent?.authors ? globalContent?.authors[0]?.bio_page : '';
   const globalCanonicalPath = globalContent?.canonical_url;
@@ -514,7 +514,12 @@ const MetaData: React.FC<Props> = ({
   );
 
   if (outputCanonicalLink) {
-    const defaultResolution = getPageCanonicalUrl(pageType, canonicalDomain || websiteDomain, gc, requestUri);
+    const defaultResolution = getPageCanonicalUrl(
+      pageType,
+      canonicalDomain || websiteDomain,
+      gc,
+      requestUri,
+    );
     const canonicalUrl = canonicalResolver
       ? canonicalResolver(pageType, defaultResolution)
       : defaultResolution;

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -93,7 +93,9 @@ const buildUrl = (domain, path) => {
 };
 
 const getUrlParameters = (requestUri = ''): {[key: string]: string | [string]} => {
-  const matches = Array.from(requestUri.matchAll(/(?:[\&\?]?([\w\d\%\-\.\_\~]+)=([\w\d\%\-\.\_\~]+)){:10}?/gi));
+  const matches = Array.from(
+    requestUri.matchAll(/(?:[\&\?]?([\w\d\%\-\.\_\~]{1:100})=([\w\d\%\-\.\_\~]{1:100})){:10}?/gi)
+  );
   return matches.reduce((accumulator, [, key, value]) => {
     if (accumulator.hasOwnProperty(key)) {
       return ({


### PR DESCRIPTION
## Description
Adding canonical links for all page types and adding an override for clients to define their own canonical if need be.

## Jira Ticket
- [TMEDIA-534](https://arcpublishing.atlassian.net/browse/TMEDIA-534)

## Acceptance Criteria
* Ensure canonical URL matches documentation - https://corecomponents.arcpublishing.com/alc/arc-products/themes/user-docs/page-template-guide/page-types/#link-rel-=-“canonical”
  * Standalone content item pages (Article, Video, Gallery):
    * WebsiteDomain of the primary_website + canonical_url in the content’s ANS
  * Results pages (Tag, Author, Section, Search, Homepage):
    * WebsiteDomain of the website being rendered + self-referencing path
  * New prop outputCanonicalLink
    * Boolean - defaults to false
    * If true canonical link is rendered for all documented scenarios above
  * Update MetaData component documentation

### dev notes:
  * `section` will resolve to : domain + {globalContent._id}
    * the _id in our sections is the path
  * `author` will resolve to : domain + {globalContent.authors[0].bio_page}
  * `search` will resolve to : domain + /search/{globalContent.metadata.q}

## Test Steps
1. Checkout the branch: `git checkout tmedia-534-canonical`
2. Run local fusion: `npx fusion start -f -l @wpmedia/engine-theme-sdk,@wpmedia/default-output-block`
3. Modify `fusion-news-theme-blocks/blocks/default-output-block/output-types` : ~177 to add `outputCanonicalLink`
```
  <MetaData
    /* ... */
    outputCanonicalLink
  />
```
4. Open http://localhost/pf/local/2020/07/09/headlinesbasic/?_website=the-gazette to validate the `article` head:
![image](https://user-images.githubusercontent.com/2287238/143130619-c33eed46-4b2c-425e-9fc5-f14a61088070.png)
5. Open http://localhost/pf/local/?_website=the-gazette to validate the `section` head: 
![image](https://user-images.githubusercontent.com/2287238/143131051-fbda6ecc-82f4-4eb1-a18f-aacf5d47108d.png)
6. Open http://localhost/pf/homepage/?_website=the-sun to validate the `home` head: 
![image](https://user-images.githubusercontent.com/2287238/143131244-d75acc1d-9159-4250-9fe6-7dfc86117b5a.png)
7. Open http://localhost/pf/bio_page/?_website=the-gazette to validate the `author` head: 
![image](https://user-images.githubusercontent.com/2287238/143131599-8a168ab0-2aa0-4a11-bcdc-5001906cc073.png)
8. Open http://localhost/pf/demo-video-leaf-page/?_website=the-gazette to validate the `video` head: 
![image](https://user-images.githubusercontent.com/2287238/143131844-efc89ef3-1212-4c85-9a69-e664f5d57be6.png)
9. Open http://localhost/pf/gallery-taboola/?_website=the-sun to validate the `gallery` head:
![image](https://user-images.githubusercontent.com/2287238/143132048-78cd3837-11d5-4b28-8ea6-e13c6fcccf61.png)
10. Open http://localhost/pf/standalone-tag-page/?_website=the-sun to validate the `tag` head: 
![image](https://user-images.githubusercontent.com/2287238/143132183-ea2d29c1-f5e5-49e4-b494-a68f2755858d.png)
11. Open http://localhost/pf/about-us/?_website=the-sun to validate the unknown head:
![image](https://user-images.githubusercontent.com/2287238/143132457-53cee90f-71bb-42f1-9d4d-59711afe35f6.png)
12. Modify `fusion-news-theme-blocks/blocks/default-output-block/output-types` : to add `outputCanonicalLink` and the following `canonicalResolver` callback:
```
  const { globalContent, arcSite, requestUri } = useFusionContext(); // line 102

  <MetaData // line 177
    /* ... */
    outputCanonicalLink
    canonicalResolver={(pageType, defaultResolution) => {
      if (typeof pageType === 'undefined') {
        return websiteDomain + requestUri;
      }
      return defaultResolution;
    }}
  />
```
13. Open http://localhost/pf/about-us/?_website=the-sun to validate the unknown head:
![image](https://user-images.githubusercontent.com/2287238/143132884-c1919f2c-1b3d-4fb9-ac49-8bcac90c081e.png)

## Effect Of Changes
### Before
No canonical links would be displayed for the known page types.

### After
Canonical links will be provided for the known page types.  A method will allow a user to override that and use their own.

[include screenshot or gif or link to video, storybook would be awesome]

## Dependencies or Side Effects
- to test, you will need to modify your local default-output-block

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
