### PR TITLE
TMEDIA-677 Vertically center gallery 

### DIFF
--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -383,22 +383,27 @@ const Gallery: React.FC<GalleryProps> = ({
       aria-label={`${index + 1} of ${totalImages}`}
       aria-hidden={index !== page}
     >
-      { showAd && renderAd() }
-      <Image
-        url={imgContent.url}
-        alt={imgContent.alt_text}
-        smallWidth={400}
-        smallHeight={0}
-        mediumWidth={600}
-        mediumHeight={0}
-        largeWidth={800}
-        largeHeight={0}
-        lightBoxWidth={1600}
-        lightBoxHeight={0}
-        resizedImageOptions={imgContent.resized_params}
-        breakpoints={imgContent.breakpoints || {}}
-        resizerURL={resizerURL}
-      />
+      {
+        showAd
+          ? renderAd()
+          : (
+            <Image
+              url={imgContent.url}
+              alt={imgContent.alt_text}
+              smallWidth={400}
+              smallHeight={0}
+              mediumWidth={600}
+              mediumHeight={0}
+              largeWidth={800}
+              largeHeight={0}
+              lightBoxWidth={1600}
+              lightBoxHeight={0}
+              resizedImageOptions={imgContent.resized_params}
+              breakpoints={imgContent.breakpoints || {}}
+              resizerURL={resizerURL}
+            />
+          )
+      }
     </ImageWrapper>
   );
 

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -119,6 +119,7 @@ export const ImageWrapper = styled.div<{ aspectRatio: number }>`
   transition-property: transform, visibility;
   font-size: 0;
   margin: auto;
+  justify-content: center;
   img {
     aspect-ratio: ${({ aspectRatio }): number => aspectRatio};
     object-fit: contain;
@@ -134,9 +135,6 @@ export const AdWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
 
   .advertisement-label {


### PR DESCRIPTION
## Description
Vertically center gallery images

## Jira Ticket
- [TMEDIA-677](https://arcpublishing.atlassian.net/browse/TMEDIA-677)

## Acceptance Criteria
On safari, the image should be vertically centered in the gallery

On safari, the ad in the gallery should be vertically centered in the gallery and no part of the image should be shown

## Test Steps


### Storybook

1. Open safari 
2. Open the chromatic page for this 
3. Go to the gallery
4. Open the new tab so it's full-screen 
![Screen Shot 2022-02-09 at 15 24 49](https://user-images.githubusercontent.com/5950956/153292610-8bc7091b-2563-446e-a3e4-6af243d90f4b.png)

5. Scroll around and see evenly-distributed black area above and below the images
6. Go to a story with an ad 

7. Scroll to the ad. You should not see the image underneath the ad. (It's actually no longer rendered now, rather than hidden below. In my mind, this is an improvement.) 
![Screen Shot 2022-02-09 at 15 31 32](https://user-images.githubusercontent.com/5950956/153293544-3209831e-509c-4ef9-9f90-b54baca0ced9.png)


### Live 

1. Link engine theme sdk locally `npx fusion start -f -l @wpmedia/engine-theme-sdk`
2. Open safari http://localhost/pf/gallery-ad-test/?_website=the-sun
3. See the ads render on sliding through the gallery
4. Ensure images are vertically centered

![Screen Shot 2022-02-09 at 17 24 50](https://user-images.githubusercontent.com/5950956/153307581-caf37658-3713-4094-a494-3b2371412df8.png)


## Effect Of Changes
### Before

![Screen Shot 2022-02-09 at 14 45 27](https://user-images.githubusercontent.com/5950956/153292851-18a9c7c9-e6e0-4f0b-a665-25c83e5ffd7e.png)

### After
![Screen Shot 2022-02-09 at 14 45 04](https://user-images.githubusercontent.com/5950956/153292504-1bbdf890-0e7f-48d2-8ab5-3ac6ce5ef7fc.png)

## Dependencies or Side Effects
- When there's an ad above an image, the interaction of the ad moving over the image has changed. I'm not sure if this was the desired behavior from before

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
