### PR TITLE
TMEDIA 680: Target powa class for setting powa properties

### DIFF
--- a/src/components/VideoPlayer/formatEmbedMarkup.test.tsx
+++ b/src/components/VideoPlayer/formatEmbedMarkup.test.tsx
@@ -26,13 +26,6 @@ describe('If the embed html is valid', () => {
       + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
       + 'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
 
-    // in original test, the script tag was commented out strangely
-    // const expectedEmbed =
-    //   '<div class="powa"  data-autoplay=true data-muted=true' +
-    //   ' id="powa-e924" data-org="corecomponents" data-env="prod" data-uuid="e924e51b" ' +
-    //   'data-aspect-ratio="0.562" data-api="prod"><script src="//xxx.cloud' +
-    //   'front.net/prod/powaBoot.js?org=corecomponents"></script></div>';
-
     const embedHTMLOutput = formatEmbedMarkup(testEmbed, true, false);
     expect(embedHTMLOutput).toMatch(/data-autoplay="true"/i);
     expect(embedHTMLOutput).toMatchInlineSnapshot(
@@ -43,12 +36,6 @@ describe('If the embed html is valid', () => {
     const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
       + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
       + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
-
-    // const expectedEmbed =
-    //   '<div class="powa"  data-autoplay=true data-muted=true  data-playthrough=true' +
-    //   ' id="powa-e924" data-org="corecomponents" data-env="prod" data-uuid="e924e51b" ' +
-    //   'data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloud' +
-    //   'front.net/prod/powaBoot.js?org=corecomponents"></script></div>';
 
     const embedHTMLOutput = formatEmbedMarkup(testEmbed, true, true);
     expect(embedHTMLOutput).toMatch(/data-autoplay="true"/i);
@@ -74,8 +61,8 @@ describe('If the embed html is valid', () => {
   });
   it('passes in an override aspect ratio', () => {
     const testEmbed = '<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"'
-    + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
-    + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+      + ' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script '
+      + 'src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
 
     // 0.3 target aspect ratio
     const embedHTMLOutput = formatEmbedMarkup(testEmbed, false, false, 0.3);
@@ -83,5 +70,27 @@ describe('If the embed html is valid', () => {
     expect(embedHTMLOutput).toMatch(/data-aspect-ratio="0.3"/i);
     // 0.562 was passed in default
     expect(embedHTMLOutput).not.toMatch(/data-aspect-ratio="0.562"/i);
+  });
+  it('handles a non-powa parent div correctly', () => {
+    const testEmbed = `
+      <div class="goldfish-player">
+        <div class="powa" id="powa-ff" data-org="ffff" data-uuid="ffff" data-aspect-ratio="0.562">
+          <script src="//ff.cloudfront.net/prod/powaBoot.js"></script>
+        </div>
+      </div>
+    `;
+    const embedHTMLOutput = formatEmbedMarkup(testEmbed, true, true);
+
+    // ensure no parent autoplay is added
+    expect(embedHTMLOutput.match(/<div class="goldfish-player">/i)[0]).toBe('<div class="goldfish-player">');
+
+    expect(embedHTMLOutput).toMatchInlineSnapshot(`
+      "<div class=\\"goldfish-player\\">
+              <div class=\\"powa\\" id=\\"powa-ff\\" data-org=\\"ffff\\" data-uuid=\\"ffff\\" data-aspect-ratio=\\"0.562\\" data-autoplay=\\"true\\" data-muted=\\"true\\" data-playthrough=\\"true\\">
+                <script src=\\"//ff.cloudfront.net/prod/powaBoot.js\\"></script>
+              </div>
+            </div>
+          "
+    `);
   });
 });

--- a/src/components/VideoPlayer/formatEmbedMarkup.tsx
+++ b/src/components/VideoPlayer/formatEmbedMarkup.tsx
@@ -25,22 +25,24 @@ function formatEmbedMarkup(
   overrideAspectRatio?: number,
 ): string {
   if (embedHTML) {
-    const embedHTMLWithPlayStatus = convertStringToNode(embedHTML).querySelector('div');
+    const embedHTMLWithPlayStatus = convertStringToNode(embedHTML);
 
     if (enableAutoplay) {
-      embedHTMLWithPlayStatus.setAttribute('data-autoplay', 'true');
-      embedHTMLWithPlayStatus.setAttribute('data-muted', 'true');
+      // powa is guaranteed to be in the embedHTML, according to Powa team
+      embedHTMLWithPlayStatus.querySelector('.powa').setAttribute('data-autoplay', 'true');
+      embedHTMLWithPlayStatus.querySelector('.powa').setAttribute('data-muted', 'true');
     }
 
     if (playthrough) {
-      embedHTMLWithPlayStatus.setAttribute('data-playthrough', 'true');
+      embedHTMLWithPlayStatus.querySelector('.powa').setAttribute('data-playthrough', 'true');
     }
 
     if (overrideAspectRatio) {
-      embedHTMLWithPlayStatus.setAttribute('data-aspect-ratio', overrideAspectRatio.toString());
+      embedHTMLWithPlayStatus.querySelector('.powa').setAttribute('data-aspect-ratio', overrideAspectRatio.toString());
     }
 
-    return embedHTMLWithPlayStatus.outerHTML;
+    // innerhtml ensures body tag not rendered
+    return embedHTMLWithPlayStatus.innerHTML;
   }
 
   // if falsy (empty string, undefined, or null), return empty string

--- a/stories/VideoPlayer.stories.mdx
+++ b/stories/VideoPlayer.stories.mdx
@@ -31,3 +31,10 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
         <VideoPlayer id="" isPlaythrough={true} embedMarkup={'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'}  />
     </Story>
 </Canvas>
+
+### **Video Player with autoplay and other div wrapper**
+<Canvas>
+    <Story name="Video Player with autoplay and other div wrapper">
+        <VideoPlayer id="" enableAutoplay={true} embedMarkup={'<div class="goldfish-player"><div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div></div>'}  />
+    </Story>
+</Canvas>


### PR DESCRIPTION
## Description
Target powa class for powa settings -- not first child

## Jira Ticket
- [TMEDIA-680](https://arcpublishing.atlassian.net/browse/TMEDIA-680)

## Acceptance Criteria
- Renders with different parent html in embed_html

## Test Steps

### Storybook
- `npm run storybook` or in the cloud
- See the new test for video player that shows parent html around the powa player
- Ensure that that story video still has an autoplaying video 

### Live 


1. LInk engine theme sdk via .env property `ENGINE_SDK_REPO=/{your path}/engine-theme-sdk`
2. `npx fusion start -f`

should see
```
Using published blocks
--- Linking engine sdk
The CSS_FRAMEWORK_REPO variable was not found. Using published version
The THEME_COMPONENTS_REPO variable was not found. Using published version
The FUSION_REPO variable was not found. Using image
Removing fusion-origin        ... done
```

3. Go to http://localhost/pf/demo-video-block-homepage/?_website=the-gazette. See video autoplay as expected

## Effect Of Changes
### Before
- Targeted whatever was the first div of the embed_html

### After
- Targets the powa class because video center users can configured that embed html with video center

## Dependencies or Side Effects
- None. Makes the product more dynamic to allowing video center embed changes 

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
