### PR TITLE
TMEDIA-770 - Missing Trailing Slash

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -1796,7 +1796,7 @@ describe("the meta data", () => {
 			});
 			const wrapper = wrapperGenerator(metaValue, globalContentComplete, "", null, null, true);
 			expect(wrapper.find('link[rel="canonical"]').prop("href")).toBe(
-				`${websiteDomain}${globalContentComplete._id}`
+				`${websiteDomain}${globalContentComplete._id}/`
 			);
 		});
 

--- a/src/components/MetaData/index.tsx
+++ b/src/components/MetaData/index.tsx
@@ -4,6 +4,7 @@ import React, { ReactElement } from "react";
 import ReactDOMServer from "react-dom/server";
 import PropTypes from "prop-types";
 import { URL } from "url";
+import fixTrailingSlash from "../../utils/formatURL";
 
 interface CustomMetaData {
 	metaName: string;
@@ -95,7 +96,7 @@ const generateCustomMetaTags = (metaData, MetaTag, MetaTags): ReactElement => {
 const buildUrl = (domain, path): string => {
 	try {
 		const url = new URL(path || "", domain);
-		return url.href;
+		return fixTrailingSlash(url.href);
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
## Description

Use fixTrailingSlash function to ensure URLs always have a trailing slash

## Jira Ticket

- [TMEDIA-770](https://arcpublishing.atlassian.net/browse/TMEDIA-770)

## Test Steps

Tests where updated to account for trailing slash which should be enough, but to test using Fusion use the following steps

1. Checkout this branch - `git checkout TMEDIA-770-canonical-trailing-slash`
2. Ensure Feature Pack repo has the SDK linked in your .env file `ENGINE_SDK_REPO`
3. Run fusion and then go to a section page - http://localhost/arts/?_website=the-gazette

## Review Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
