### PR TITLE
HOTFIX Tmedia 840 empty credits 

### DIFF
--- a/src/components/VideoPlayer/index.test.tsx
+++ b/src/components/VideoPlayer/index.test.tsx
@@ -267,5 +267,27 @@ describe("MutationObserver", () => {
 			);
 			expect(wrapper.find("p").length).toBe(0);
 		});
+		it("takes in empty caption, title and credits and renders the video", () => {
+			const testEmbed =
+				'<div class="powa" id="powa-e924" data-org="corecomponents" data-env="prod"' +
+				' data-uuid="e924e51b" data-aspect-ratio="0.562" data-api="prod"><script ' +
+				'src="//xxx.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+			const wrapper = mount(
+				<VideoPlayer
+					embedMarkup={testEmbed}
+					id="targetId"
+					shrinkToFit={false}
+					caption=""
+					credits={{}}
+					subtitle=""
+					displayCredits={false}
+				/>
+			);
+
+			// doesn't show any caption or credits
+			expect(wrapper.find("p").length).toBe(0);
+			// still renders the video with no errors
+			expect(wrapper.find("styled__VideoWrap").length).toBe(1);
+		});
 	});
 });

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -59,7 +59,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 	const hasCaption =
 		(subtitle && displayTitle) ||
 		(caption && displayCaption) ||
-		((credits?.affiliation.length > 0 || credits?.by.length > 0) && displayCredits);
+		((credits?.affiliation?.length > 0 || credits?.by?.length > 0) && displayCredits);
 
 	// migration from video component
 	// will fallback to uuid if id is undefined with defaulting to falsy ''

--- a/stories/VideoPlayer.stories.mdx
+++ b/stories/VideoPlayer.stories.mdx
@@ -194,3 +194,18 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 		/>
 	</Story>
 </Canvas>
+
+### **Video with empty credits object and no subtitle or title **
+
+<Canvas>
+	<Story name="Video with empty credits object and no subtitle or title">
+		<VideoPlayer
+			id=""
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+			credits={{}}
+			displayTitle={false}
+		/>
+	</Story>
+</Canvas>


### PR DESCRIPTION
## Description

Handle empty credits object 

Jenae described in slack of testing this in sandbox beta

## Jira Ticket

- [tmedia-840](https://arcpublishing.atlassian.net/browse/TMEDIA-840)

## Acceptance Criteria

- Video should render receiving an empty credits object

## Test Steps

- In the feature pack, `git checkout news`
- In the `.env`, link the engine theme sdk `ENGINE_SDK_REPO=/{your path}/engine-theme-sdk`
- `npx fusion start -f`
- See `--- Linking engine sdk`
- Wait until the webpack build is over
- Clone page video leaf metadata 
<img width="1048" alt="Screen Shot 2022-04-25 at 12 57 33" src="https://user-images.githubusercontent.com/5950956/165147293-b8ec2ccb-7099-4633-9ef1-6cc2644121dd.png">
- Update the global content to be `bd9224f4-199e-426a-9a0b-b43acb840990`
- Click hide title on the video center 
- Make sure the video still renders with no error 
<img width="1027" alt="Screen Shot 2022-04-25 at 13 03 06" src="https://user-images.githubusercontent.com/5950956/165147510-494798cd-de8f-4cf9-a5d7-f7f6f239760e.png">

## Effect Of Changes

### Before

video doesn't render, shows error 

<img width="494" alt="Screen Shot 2022-04-25 at 13 03 01" src="https://user-images.githubusercontent.com/5950956/165147634-153dc8e2-7f07-455f-afa8-1be5e968d688.png">


### After

title renders with no error
<img width="1027" alt="Screen Shot 2022-04-25 at 13 03 06" src="https://user-images.githubusercontent.com/5950956/165147547-21217d1f-aaf9-41c4-bec3-234afc56f57d.png">

## Dependencies or Side Effects
- This is going into sandbox first, according to product. then hotfix to stable


## Review Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.
