### PR TITLE
THEMES-1062: Gallery component | Eager load image

### DIFF
--- a/src/components/Gallery/index.test.tsx
+++ b/src/components/Gallery/index.test.tsx
@@ -1044,4 +1044,24 @@ describe("the gallery block", () => {
 			expect(wrapper.find("#gallery-pos-1 .ad-block").length).toBe(1);
 		});
 	});
+
+	describe("the eagerLoadFirstImage prop", () => {
+		it("sets the first image to load eager when true", () => {
+			const wrapper = mount(
+				<Gallery galleryElements={mockGallery} eagerLoadFirstImage />
+			);
+			const images = wrapper.find("Image");
+			expect(images.at(0).prop("loading")).toBe("eager");
+			expect(images.at(1).prop("loading")).toBe("lazy");
+		});
+		
+		it("sets the first image to load lazy when false", () => {
+			const wrapper = mount(
+				<Gallery galleryElements={mockGallery} eagerLoadFirstImage={false} />
+			);
+			const images = wrapper.find("Image");
+			expect(images.at(0).prop("loading")).toBe("lazy");
+			expect(images.at(1).prop("loading")).toBe("lazy");
+		});
+	})
 });

--- a/src/components/Gallery/index.tsx
+++ b/src/components/Gallery/index.tsx
@@ -92,6 +92,7 @@ interface GalleryProps extends CreditOptions {
 	previousImagePhrase?: string;
 	nextImagePhrase?: string;
 	controlsFont?: string;
+	eagerLoadFirstImage?: boolean;
 }
 
 declare interface EventOptionsInterface {
@@ -116,6 +117,7 @@ const Gallery: React.FC<GalleryProps> = ({
 	displayTitle = true,
 	displayCaption = true,
 	displayCredits = true,
+	eagerLoadFirstImage = false,
 }) => {
 	const galleryRef = useRef(null);
 	const carouselRef = useRef(null);
@@ -379,6 +381,7 @@ const Gallery: React.FC<GalleryProps> = ({
 					resizedImageOptions={imgContent.resized_params}
 					breakpoints={imgContent.breakpoints || {}}
 					resizerURL={resizerURL}
+					loading={eagerLoadFirstImage && index === 0 ? 'eager' : 'lazy'}
 				/>
 			)}
 		</ImageWrapper>


### PR DESCRIPTION
## Description

This PR adds a prop to control the loading strategy of the first image in the Gallery component. It can be eager loaded if `true`, or lazy loaded if false.

## Jira Ticket

- [THEMES-1062](https://arcpublishing.atlassian.net/browse/THEMES-1062)

## Acceptance Criteria

Allow blocks using the gallery sdk component to set the loading strategy of the images.

## Test Steps

- See https://github.com/WPMedia/arc-themes-blocks/pull/1639 for testing instructions.

## Review Checklist

- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.


[THEMES-1062]: https://arcpublishing.atlassian.net/browse/THEMES-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ