### PR TITLE
THEMES-1102: Update timezone package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13348,9 +13348,9 @@
       }
     },
     "@wpmedia/timezone": {
-      "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/timezone/1.1.1/0ad6c48a887bc2b122d141a1eb5fb9a81b5f2ee7195d0d81f38aab7366919c2b",
-      "integrity": "sha512-nN6M2q8cyJELhihJ65t4CVFWr7QgZSnO+aAEXVFdh/k9RpQJd7EtGVLjZyd8HzAFwhiGv+O4Iz7nclbOnNXEWg=="
+      "version": "1.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/timezone/1.1.2/4c7845ae0774bed86ce2136af1537afa0634332a",
+      "integrity": "sha512-rRwGeolQP0+0Psx5Q8FPMndQrodWHaqhxoylO24Vb9SCsFAxesNBHw7Bq7xNE+bWocV35Ze2WUw9LybbzfUF9w=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",


### PR DESCRIPTION
## Description

This PR updates the timezone package used by engine-theme-sdk. The primary purpose is to fix an issue with timezones in Mexico, as they no longer observe daylight savings time.
## Jira Ticket

- [THEMES-1102](https://arcpublishing.atlassian.net/browse/THEMES-1102)

## Acceptance Criteria

The localized dates appear with the correct timezone modifiers.

## Test Steps

- Checkout this branch `git checkout THEMES-1102`.
- In the feature pack, make sure the `news` branch is up to date, and set the `timeZone` for one of the sites as `America/Mexico_City`.
- Start up the feature pack on the `news` branch, making sure `ENGINE_SDK_REPO` is set in the `.env`.
- Create a test page with the 'Date - Arc Block`. Create a new story in Composer and set that as the global content for the page.
- The date displayed should have the proper offset of GMT -6 and not GMT -5.

## Review Checklist

- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.


[THEMES-1102]: https://arcpublishing.atlassian.net/browse/THEMES-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ