### PR TITLE
THEMES-1479: 

### DIFF
--- a/src/components/MetaData/index.test.tsx
+++ b/src/components/MetaData/index.test.tsx
@@ -44,7 +44,7 @@ const globalContentComplete = {
 	},
 	promo_items: {
 		basic: {
-			url: "awesome-url",
+			url: "https://awesome-url/image.jpg",
 			alt_text: "alt text",
 		},
 	},
@@ -73,7 +73,7 @@ const globalContentLeadArt = {
 	promo_items: {
 		lead_art: {
 			type: "image",
-			url: "awesome-url",
+			url: "https://awesome-url/image.jpg",
 		},
 	},
 };
@@ -85,7 +85,7 @@ const globalContentLeadArtWithResize = {
 				0x0: "I0HK-BD7QKeAN9drBwVrYoryXDE=filters:format(jpg):quality(70):focal(3699x534:3709x544)/",
 			},
 			type: "image",
-			url: "awesome-url",
+			url: "https://awesome-url/image.jpg",
 		},
 	},
 };

--- a/src/components/MetaData/promoImageHelper.ts
+++ b/src/components/MetaData/promoImageHelper.ts
@@ -6,10 +6,9 @@ export const getImgURL = (metaValue, metaType = "og:image", globalContent, resiz
 			// eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
 			const Thumbor = require("thumbor-lite");
 			const thumbor = new Thumbor(RESIZER_SECRET_KEY, resizerURL);
-			const imgSrc = _url
-				.replace(/^http[s]?:\/\//, "")
-				.replace(" ", "%20")
-				.replace("?", "%3F");
+			const imgSrc = new URL(_url)
+				.toString()
+				.replace(/^http[s]?:\/\//, "");
 			/*
         We need the focal point out of the resize options to use as a filter
         for the thumbor image being used here


### PR DESCRIPTION
## Description

PR to fix incomplete escaping of the image source URL in the MetaData helper.

## Jira Ticket

- [THEMES-1479](https://arcpublishing.atlassian.net/browse/THEMES-1479)

## Acceptance Criteria

Code scanning alert is remedied.

## Test Steps

- Checkout branch `git checkout THEMES-1479`
- Run fusion with `ENGINE_SDK_REPO=` set in your `.env`
- Visit any article page with a promo item set.
- The `og:image` and `twitter:image` meta fields should still have working images set in the `content` attribute.

## Review Checklist

- [x] Confirmed all the test steps above are working
- [x] Confirmed there are no linter errors
- [x] Confirmed this PR has reasonable code coverage
  - [x] Confirmed this PR has unit test files
  - [x] Ran `npm test`, made sure all tests are passing
  - [x] If the amount of work to write unit tests for this change are excessive,
        please explain why (so that we can fix it whenever it gets refactored).
- [x] Confirmed relevant documentation has been updated/added.


[THEMES-1479]: https://arcpublishing.atlassian.net/browse/THEMES-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ